### PR TITLE
Add amplitude to NativeVibration

### DIFF
--- a/korge/src/androidMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
+++ b/korge/src/androidMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
@@ -1,16 +1,56 @@
 package com.soywiz.korge.service.vibration
 
-import android.annotation.*
-import android.os.*
-import android.support.v4.content.ContextCompat.*
-import com.soywiz.klock.*
-import com.soywiz.korge.android.*
-import com.soywiz.korge.view.*
+import android.annotation.SuppressLint
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.support.v4.content.ContextCompat.getSystemService
+import com.soywiz.klock.TimeSpan
+import com.soywiz.korge.android.androidActivity
+import com.soywiz.korge.view.Views
+import kotlin.math.abs
+import kotlin.math.min
 
-actual class NativeVibration actual constructor(val views: Views) {
-    @SuppressLint("MissingPermission")
-    actual fun vibrate(pattern: Array<TimeSpan>) {
-        val v = getSystemService(views.androidActivity, Vibrator::class.java)
-        v?.vibrate(VibrationEffect.createWaveform(pattern.map { it.millisecondsLong }.toLongArray(), -1))
+actual class NativeVibration actual constructor(views: Views) {
+
+    companion object {
+        private const val NO_REPEAT = -1
     }
+
+    private val vibrator = getSystemService(views.androidActivity, Vibrator::class.java)
+
+    /**
+     * @param timings list of alternating ON-OFF durations in milliseconds. Staring with ON.
+     * @param amplitudes list of intensities of the vibration. A `0.2` results in 20% vibration power.
+     */
+    @ExperimentalUnsignedTypes
+    @SuppressLint("MissingPermission")
+    actual fun vibratePattern(timings: Array<TimeSpan>, amplitudes: Array<Double>) {
+        val onOffTimings = (listOf(TimeSpan.NULL) + timings).map { it.millisecondsLong }.toLongArray()
+        if (amplitudes.size != onOffTimings.size) {
+            vibrator?.vibrate(VibrationEffect.createWaveform(onOffTimings, NO_REPEAT))
+        } else {
+            vibrator?.vibrate(
+                VibrationEffect.createWaveform(onOffTimings, amplitudes.map {it.toAndroidAmplitude()}.toIntArray(), NO_REPEAT)
+            )
+        }
+    }
+
+    /**
+     * @param time vibration duration in milliseconds
+     * @param amplitude percentage intensity of the vibration. A `0.2` results in 20% vibration power.
+     */
+    @ExperimentalUnsignedTypes
+    @SuppressLint("MissingPermission")
+    actual fun vibrate(time: TimeSpan, amplitude: Double) {
+        vibrator?.vibrate(VibrationEffect.createOneShot(time.millisecondsLong, amplitude.toAndroidAmplitude()))
+    }
+
+    /**
+     * @return amplitude value between [0 - 255]
+     */
+    private fun Double.toAndroidAmplitude() : Int{
+        val amplitude = 255 * abs(this)
+        return min(amplitude, 1.0).toInt()
+    }
+
 }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
@@ -1,8 +1,27 @@
 package com.soywiz.korge.service.vibration
 
-import com.soywiz.klock.*
-import com.soywiz.korge.view.*
+import com.soywiz.klock.TimeSpan
+import com.soywiz.korge.view.Views
 
+/**
+ * Support for device vibrations. Currently only works in Browser and Android target.
+ * The `amplitude` is only available on android.
+ */
 expect class NativeVibration constructor(views: Views) {
-    fun vibrate(pattern: Array<TimeSpan>)
+
+    /**
+     * @param timings list of alternating ON-OFF durations in milliseconds. Staring with ON.
+     * @param amplitudes list of intensities of the vibration. A `0.2` results in 20% vibration power.
+     *        Only supported on Android target. Ignored if the size is not equal with the timings.
+     */
+    @ExperimentalUnsignedTypes
+    fun vibratePattern(timings: Array<TimeSpan>, amplitudes: Array<Double> = emptyArray())
+
+    /**
+     * @param time vibration duration in milliseconds
+     * @param amplitude percentage intensity of the vibration. A `0.2` results in 20% vibration power.
+     *        Only supported on Android target.
+     */
+    @ExperimentalUnsignedTypes
+    fun vibrate(time: TimeSpan, amplitude: Double = 1.0)
 }

--- a/korge/src/jsMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
+++ b/korge/src/jsMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
@@ -1,11 +1,26 @@
 package com.soywiz.korge.service.vibration
 
-import com.soywiz.klock.*
-import com.soywiz.korge.view.*
-import kotlin.browser.*
+import com.soywiz.klock.TimeSpan
+import com.soywiz.korge.view.Views
+import kotlin.browser.window
 
 actual class NativeVibration actual constructor(val views: Views) {
-    actual fun vibrate(pattern: Array<TimeSpan>) {
-        window.navigator.vibrate(pattern.map { it.milliseconds }.toTypedArray())
+
+    /**
+     * @param timings list of alternating ON-OFF durations in milliseconds. Staring with ON.
+     * @param amplitudes has no effect on JS backend
+     */
+    @ExperimentalUnsignedTypes
+    actual fun vibratePattern(timings: Array<TimeSpan>, amplitudes: Array<Double>) {
+        window.navigator.vibrate(timings.map { it.milliseconds }.toTypedArray())
+    }
+
+    /**
+     * @param time vibration duration in milliseconds
+     * @param amplitude has no effect on JS backend
+     */
+    @ExperimentalUnsignedTypes
+    actual fun vibrate(time: TimeSpan, amplitude: Double) {
+        window.navigator.vibrate(time.milliseconds)
     }
 }

--- a/korge/src/jvmMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
+++ b/korge/src/jvmMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
@@ -1,9 +1,22 @@
 package com.soywiz.korge.service.vibration
 
-import com.soywiz.klock.*
-import com.soywiz.korge.view.*
+import com.soywiz.klock.TimeSpan
+import com.soywiz.korge.view.Views
 
 actual class NativeVibration actual constructor(val views: Views) {
-    actual fun vibrate(pattern: Array<TimeSpan>) {
+    /**
+     * @param timings list of alternating ON-OFF durations in milliseconds. Staring with ON.
+     * @param amplitudes list of intensities of the vibration. A `0.2` results in 20% vibration power.
+     */
+    @ExperimentalUnsignedTypes
+    actual fun vibratePattern(timings: Array<TimeSpan>, amplitudes: Array<Double>) {
+    }
+
+    /**
+     * @param time vibration duration in milliseconds
+     * @param amplitude percentage intensity of the vibration. A `0.2` results in 20% vibration power.
+     */
+    @ExperimentalUnsignedTypes
+    actual fun vibrate(time: TimeSpan, amplitude: Double) {
     }
 }

--- a/korge/src/nativeCommonMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
+++ b/korge/src/nativeCommonMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
@@ -1,9 +1,22 @@
 package com.soywiz.korge.service.vibration
 
-import com.soywiz.klock.*
-import com.soywiz.korge.view.*
+import com.soywiz.klock.TimeSpan
+import com.soywiz.korge.view.Views
 
 actual class NativeVibration actual constructor(val views: Views) {
-    actual fun vibrate(pattern: Array<TimeSpan>) {
+    /**
+     * @param timings list of alternating ON-OFF durations in milliseconds. Staring with ON.
+     * @param amplitudes list of intensities of the vibration. A `0.2` results in 20% vibration power.
+     */
+    @ExperimentalUnsignedTypes
+    actual fun vibratePattern(timings: Array<TimeSpan>, amplitudes: Array<Double>) {
+    }
+
+    /**
+     * @param time vibration duration in milliseconds
+     * @param amplitude percentage intensity of the vibration. A `0.2` results in 20% vibration power.
+     */
+    @ExperimentalUnsignedTypes
+    actual fun vibrate(time: TimeSpan, amplitude: Double) {
     }
 }


### PR DESCRIPTION
Without JDoc the vibration usage is hard to understand and behaves different on JS and Android. And it always uses the maxium vibration amplitude.
For example to vibrate 200ms on Android, you had to write:
``` kotlin
vibrate(longArrayOf(0, 42))
```

**Changes**
* Add `vibrate(time: TimeSpan, amplitude: UInt)`
  * Add single vibration
  * Add amplitude for Android target (_amplitude intensity of the vibration [0-255])_
* Renamed `vibrate(..)` to `vibratePattern` - nessesary to resolve name clash on expect/actual matching
* Renamed pattern to timings
* Fix pattern usage:
   Pattern is always a list of timings for ON and OFF sequences. But on JS it starts with ON, on Android 
  with OFF. So this fix adds a empty off timing for Android.
* Add JDoc for vibration methods

It's discussible if `amplitude` should be
1. A Int range from 0 - 255
2. A UInt range from 0 - 255
3. A Int range from 0 - 100
4. A Double range from 0 - 1

I have chosen 4. because of carlos 😉.

I had problems to build korge, because of:
> Expected class 'NativeVibration' has no actual declaration in module
> Expected object 'NativeStorage' has no actual declaration in module

![2020-01-20_20h52_08](https://user-images.githubusercontent.com/1190109/72755980-28acc580-3bcc-11ea-8c55-8db568b696a1.png)

So I only tested the vibration on a separate android project.