### PR TITLE
Fix native vibration amplitude on Android

### DIFF
--- a/korge/src/androidMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
+++ b/korge/src/androidMain/kotlin/com/soywiz/korge/service/vibration/NativeVibration.kt
@@ -50,7 +50,7 @@ actual class NativeVibration actual constructor(views: Views) {
      */
     private fun Double.toAndroidAmplitude() : Int{
         val amplitude = 255 * abs(this)
-        return min(amplitude, 1.0).toInt()
+        return min(amplitude, 255.0).toInt()
     }
 
 }


### PR DESCRIPTION
Now I know hot to build and test it locally. And of course it was broken.
The `toAndroidAmplitude` returned maximum 1 😣