### PR TITLE
Fix uninitialized exception in MouseEvents

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/input/MouseEvents.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/input/MouseEvents.kt
@@ -194,8 +194,8 @@ class MouseEvents(override val view: View) : MouseComponent, UpdateComponentWith
 	}
 
 	override fun update(views: Views, ms: Double) {
-		val dtMs = ms.toInt()
 		if (!view.mouseEnabled) return
+        this.views = views
 
 		views.mouseDebugHandlerOnce {
 			views.debugHandlers += { ctx ->


### PR DESCRIPTION
There is an uninitialized `views` exception in `MouseEvents` in special cases when `update` function is called before any events are performed (`views` is initialized only in `onMouseEvent` function). This PR fixes this.