### PR TITLE
Add RoundRect as a separate view

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/RoundRect.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/RoundRect.kt
@@ -1,0 +1,65 @@
+package com.soywiz.korge.view
+
+import com.soywiz.korge.ui.*
+import com.soywiz.korim.color.*
+import com.soywiz.korma.geom.vector.*
+
+/** Creates a new [RoundRect] of size [width]x[height] and [color]
+ *  and allows you to configure it via [callback].
+ *  Once created, it is added to this receiver [Container].
+ **/
+inline fun Container.roundRect(
+    width: Number,
+    height: Number,
+    rx: Number,
+    ry: Number = rx,
+    color: RGBA = Colors.WHITE,
+    autoScaling: Boolean = true,
+    callback: @ViewsDslMarker RoundRect.() -> Unit = {}
+) = RoundRect(
+    width.toDouble(),
+    height.toDouble(),
+    rx.toDouble(),
+    ry.toDouble(),
+    color,
+    autoScaling
+).addTo(this).apply(callback)
+
+/**
+ * A Rect [View] with rounded corners of size [width] and [height] with the initial [color].
+ */
+class RoundRect(
+    width: Double,
+    height: Double,
+    rx: Double,
+    ry: Double = rx,
+    color: RGBA = Colors.WHITE,
+    autoScaling: Boolean = true
+) : Graphics(autoScaling) {
+
+    override var width: Double by uiObservable(width) { updateGraphics() }
+    override var height: Double by uiObservable(height) { updateGraphics() }
+
+    override val bwidth: Double get() = width
+    override val bheight: Double get() = height
+
+    var rx: Double by uiObservable(rx) { updateGraphics() }
+    var ry: Double by uiObservable(ry) { updateGraphics() }
+
+    /** The [color] of this [RoundRect]. Alias of [colorMul]. */
+    var color: RGBA
+        get() = colorMul
+        set(value) = run { colorMul = value }
+
+    init {
+        this.colorMul = color
+        updateGraphics()
+    }
+
+    private fun updateGraphics() {
+        clear()
+        fill(Colors.WHITE) {
+            roundRect(0, 0, width, height, rx, ry)
+        }
+    }
+}

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/view/ViewsTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/view/ViewsTest.kt
@@ -119,6 +119,10 @@ class ViewsTest : ViewsForTesting() {
             assertEquals(Rectangle(0, 0, 32, 32), rect3.globalBounds)
         }
 
+        RoundRect(32.0, 24.0, 5.0, 5.0, Colors.RED).also { addChild(it) }.also { rect3 ->
+            assertEquals(Rectangle(0, 0, 32, 24), rect3.globalBounds)
+        }
+
         Circle(32.0, Colors.RED).also { addChild(it) }.also { rect3 ->
             assertEquals(Rectangle(0, 0, 64, 64).toString(), rect3.globalBounds.toString())
         }


### PR DESCRIPTION
Add RoundRect as a separate view (like SolidRect or CIrcle), so you don't have to use `graphics { ... }` when you need a rectangle with rounded corners.