### PR TITLE
Allows to install the mouse debug layer without any mouse event registered

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
@@ -8,10 +8,11 @@ import kotlinx.coroutines.*
 /**
  * Singleton root [View] and [Container] that contains a reference to the [Views] singleton and doesn't have any parent.
  */
-class Stage(val views: Views) : Container()
+class Stage(override val views: Views) : Container()
     , View.Reference
     , CoroutineScope by views
     , EventDispatcher by EventDispatcher.Mixin()
+    , ViewsScope
 {
     val injector get() = views.injector
     val ag get() = views.ag


### PR DESCRIPTION
Fixes #240

Also makes the Stage implement ViewsScope

Please, instead of squashing, let rebase and merge this so the Stage implement ViewsScope is kept in a separate commit