### PR TITLE
Filters caused black screens on AWT JVM on Macos and potentially Windows. Fixes #213

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ group=com.soywiz.korlibs.korge
 version=10-SNAPSHOT
 
 klockVersion=1.11.13
-korgwVersion=1.12.24
+korgwVersion=1.12.25
 korauVersion=1.11.10
 korimVersion=1.12.29
 kormaVersion=1.11.20


### PR DESCRIPTION
Fixes #213 

Since fixed happened on korgw but inline methods were somehow affected, we need to update korgw version here too

Fixed here: https://github.com/korlibs/korgw/pull/38