### PR TITLE
Disable DSL scope limiting by removing KorDslMarker from View.

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/Korge.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/Korge.kt
@@ -97,7 +97,7 @@ object Korge {
 		gameWindow: GameWindow? = null,
         timeProvider: HRTimeProvider = HRTimeProvider,
         injector: AsyncInjector = AsyncInjector(),
-        entry: suspend Stage.() -> Unit
+        entry: @ViewDslMarker suspend Stage.() -> Unit
 	) {
         if (!OS.isJsBrowser) {
             configureLoggerFromProperties(localCurrentDirVfs["klogger.properties"])

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/IconButton.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/IconButton.kt
@@ -8,7 +8,7 @@ inline fun Container.iconButton(
     height: Number,
     skin: UISkin = defaultUISkin,
     iconSkin: IconSkin = defaultCheckSkin,
-    block: UIButton.() -> Unit = {}
+    block: @ViewDslMarker UIButton.() -> Unit = {}
 ): IconButton = iconButton(width.toDouble(), height.toDouble(), skin, iconSkin, block)
 
 inline fun Container.iconButton(
@@ -16,7 +16,7 @@ inline fun Container.iconButton(
     height: Double = 64.0,
     skin: UISkin = defaultUISkin,
     iconSkin: IconSkin = defaultCheckSkin,
-    block: UIButton.() -> Unit = {}
+    block: @ViewDslMarker UIButton.() -> Unit = {}
 ): IconButton = IconButton(width, height, skin, iconSkin).addTo(this).apply(block)
 
 open class IconButton(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/TextButton.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/TextButton.kt
@@ -12,7 +12,7 @@ inline fun Container.textButton(
 	text: String = "Button",
 	skin: UISkin = defaultUISkin,
 	textFont: Html.FontFace = defaultUIFont,
-	block: TextButton.() -> Unit = {}
+	block: @ViewDslMarker TextButton.() -> Unit = {}
 ): TextButton = textButton(width.toDouble(), height.toDouble(), text, skin, textFont, block)
 
 inline fun Container.textButton(
@@ -21,7 +21,7 @@ inline fun Container.textButton(
     text: String = "Button",
     skin: UISkin = defaultUISkin,
     textFont: Html.FontFace = defaultUIFont,
-    block: TextButton.() -> Unit = {}
+    block: @ViewDslMarker TextButton.() -> Unit = {}
 ): TextButton = TextButton(width, height, text, skin, textFont).addTo(this).apply(block)
 
 open class TextButton(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIButton.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIButton.kt
@@ -8,14 +8,14 @@ inline fun Container.uiButton(
 	width: Number,
 	height: Number,
 	skin: UISkin = defaultUISkin,
-	block: UIButton.() -> Unit = {}
+	block: @ViewDslMarker UIButton.() -> Unit = {}
 ): UIButton = uiButton(width.toDouble(), height.toDouble(), skin, block)
 
 inline fun Container.uiButton(
     width: Double = 128.0,
     height: Double = 64.0,
     skin: UISkin = defaultUISkin,
-    block: UIButton.() -> Unit = {}
+    block: @ViewDslMarker UIButton.() -> Unit = {}
 ): UIButton = UIButton(width, height, skin).addTo(this).apply(block)
 
 open class UIButton(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UICheckBox.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UICheckBox.kt
@@ -16,7 +16,7 @@ inline fun Container.uiCheckBox(
     textFont: Html.FontFace = defaultUIFont,
     skin: UISkin = defaultUISkin,
     checkIcon: IconSkin = defaultCheckSkin,
-    block: UICheckBox.() -> Unit = {}
+    block: @ViewDslMarker UICheckBox.() -> Unit = {}
 ): UICheckBox = uiCheckBox(width.toDouble(), height.toDouble(), checked, text, textFont, skin, checkIcon, block)
 
 inline fun Container.uiCheckBox(
@@ -27,7 +27,7 @@ inline fun Container.uiCheckBox(
     textFont: Html.FontFace = defaultUIFont,
     skin: UISkin = defaultUISkin,
     checkIcon: IconSkin = defaultCheckSkin,
-    block: UICheckBox.() -> Unit = {}
+    block: @ViewDslMarker UICheckBox.() -> Unit = {}
 ): UICheckBox = UICheckBox(width, height, checked, text, textFont, skin, checkIcon).addTo(this).apply(block)
 
 open class UICheckBox(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIComboBox.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIComboBox.kt
@@ -13,7 +13,7 @@ inline fun <T> Container.uiComboBox(
 	items: List<T>,
 	verticalScroll: Boolean = true,
 	skin: ComboBoxSkin = defaultComboBoxSkin,
-	block: UIComboBox<T>.() -> Unit = {}
+	block: @ViewDslMarker UIComboBox<T>.() -> Unit = {}
 ) = uiComboBox(width.toDouble(), height.toDouble(), selectedIndex, items, verticalScroll, skin, block)
 
 inline fun <T> Container.uiComboBox(
@@ -23,7 +23,7 @@ inline fun <T> Container.uiComboBox(
     items: List<T>,
     verticalScroll: Boolean = true,
     skin: ComboBoxSkin = defaultComboBoxSkin,
-    block: UIComboBox<T>.() -> Unit = {}
+    block: @ViewDslMarker UIComboBox<T>.() -> Unit = {}
 ) = UIComboBox(width, height, selectedIndex, items, verticalScroll, skin).addTo(this).apply(block)
 
 open class UIComboBox<T>(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIProgressBar.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIProgressBar.kt
@@ -6,7 +6,7 @@ import com.soywiz.korge.view.*
 inline fun Container.uiProgressBar(
 	width: Number, height: Number, current: Number, maximum: Number,
 	skin: UISkin = defaultUISkin,
-	block: UIProgressBar.() -> Unit = {}
+	block: @ViewDslMarker UIProgressBar.() -> Unit = {}
 ): UIProgressBar = uiProgressBar(width.toDouble(), height.toDouble(), current.toDouble(), maximum.toDouble(), skin, block)
 
 inline fun Container.uiProgressBar(
@@ -15,7 +15,7 @@ inline fun Container.uiProgressBar(
     current: Double = 0.0,
     maximum: Double = 1.0,
     skin: UISkin = defaultUISkin,
-    block: UIProgressBar.() -> Unit = {}
+    block: @ViewDslMarker UIProgressBar.() -> Unit = {}
 ): UIProgressBar = UIProgressBar(width, height, current, maximum, skin).addTo(this).apply(block)
 
 open class UIProgressBar(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIScrollBar.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIScrollBar.kt
@@ -13,7 +13,7 @@ inline fun Container.uiScrollBar(
     width: Number, height: Number, current: Number, pageSize: Number, totalSize: Number, buttonSize: Number, stepSize: Number,
     direction: Direction = if (width.toDouble() > height.toDouble()) Direction.Horizontal else Direction.Vertical,
     skin: ScrollBarSkin = if (direction == Direction.Horizontal) defaultHorScrollBarSkin else defaultVerScrollBarSkin,
-    block: UIScrollBar.() -> Unit = {}
+    block: @ViewDslMarker UIScrollBar.() -> Unit = {}
 ): UIScrollBar = uiScrollBar(width.toDouble(), height.toDouble(), current.toDouble(), pageSize.toDouble(), totalSize.toDouble(), buttonSize.toDouble(),
     stepSize.toDouble(), direction, skin, block)
 
@@ -27,7 +27,7 @@ inline fun Container.uiScrollBar(
     stepSize: Double = pageSize / 10.0,
     direction: Direction = Direction.auto(width, height),
     skin: ScrollBarSkin = if (direction == Direction.Horizontal) defaultHorScrollBarSkin else defaultVerScrollBarSkin,
-    block: UIScrollBar.() -> Unit = {}
+    block: @ViewDslMarker UIScrollBar.() -> Unit = {}
 ): UIScrollBar = UIScrollBar(width, height, current, pageSize, totalSize, buttonSize, stepSize, direction, skin).addTo(this).apply(block)
 
 open class UIScrollBar(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIScrollableArea.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIScrollableArea.kt
@@ -14,7 +14,7 @@ inline fun Container.uiScrollableArea(
     horSkin: ScrollBarSkin = defaultHorScrollBarSkin,
     verSkin: ScrollBarSkin = defaultVerScrollBarSkin,
     config: UIScrollableArea.() -> Unit = {},
-    block: Container.() -> Unit = {}
+    block: @ViewDslMarker Container.() -> Unit = {}
 ): UIScrollableArea = uiScrollableArea(
     width.toDouble(), height.toDouble(), contentWidth.toDouble(), contentHeight.toDouble(), buttonSize.toDouble(),
     verticalScroll, horizontalScroll, horSkin, verSkin, config, block
@@ -31,7 +31,7 @@ inline fun Container.uiScrollableArea(
     horSkin: ScrollBarSkin = defaultHorScrollBarSkin,
     verSkin: ScrollBarSkin = defaultVerScrollBarSkin,
     config: UIScrollableArea.() -> Unit = {},
-    block: Container.() -> Unit = {}
+    block: @ViewDslMarker Container.() -> Unit = {}
 ): UIScrollableArea = UIScrollableArea(width, height, contentWidth, contentHeight, buttonSize, verticalScroll, horizontalScroll, horSkin, verSkin)
     .addTo(this).apply(config).also { block(it.container) }
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIText.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIText.kt
@@ -9,7 +9,7 @@ import com.soywiz.korma.geom.*
 inline fun Container.uiText(
     text: String, width: Number, height: Number,
     skin: TextSkin = defaultTextSkin,
-    block: UIText.() -> Unit = {}
+    block: @ViewDslMarker UIText.() -> Unit = {}
 ): UIText = uiText(text, width.toDouble(), height.toDouble(), skin, block)
 
 inline fun Container.uiText(
@@ -17,7 +17,7 @@ inline fun Container.uiText(
     width: Double = 128.0,
     height: Double = 64.0,
     skin: TextSkin = defaultTextSkin,
-    block: UIText.() -> Unit = {}
+    block: @ViewDslMarker UIText.() -> Unit = {}
 ): UIText = UIText(text, width, height, skin).addTo(this).apply(block)
 
 class UIText(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Camera.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Camera.kt
@@ -8,7 +8,7 @@ import com.soywiz.korma.interpolation.*
 /**
  * Creates a new [Camera] and attaches to [this] [Container]. The [callback] argument is called with the [Camera] injected as this to be able to configure the camera.
  */
-inline fun Container.camera(callback: Camera.() -> Unit = {}): Camera = Camera().addTo(this, callback)
+inline fun Container.camera(callback: @ViewDslMarker Camera.() -> Unit = {}): Camera = Camera().addTo(this, callback)
 
 /**
  * A [Camera] is a [Container] that allows to center its position using [setTo] and [tweenTo] methods.

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Circle.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Circle.kt
@@ -13,7 +13,7 @@ inline fun Container.circle(
     radius: Double = 16.0,
     color: RGBA = Colors.WHITE,
     autoScaling: Boolean = true,
-    callback: Circle.() -> Unit = {}
+    callback: @ViewDslMarker Circle.() -> Unit = {}
 ): Circle = Circle(radius, color, autoScaling).addTo(this, callback)
 
 /**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/ClipContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/ClipContainer.kt
@@ -1,11 +1,11 @@
 package com.soywiz.korge.view
 
 @Deprecated("Kotlin/Native boxes inline+Number")
-inline fun Container.clipContainer(width: Number, height: Number, callback: ClipContainer.() -> Unit = {}) =
+inline fun Container.clipContainer(width: Number, height: Number, callback: @ViewDslMarker ClipContainer.() -> Unit = {}) =
     clipContainer(width.toDouble(), height.toDouble(), callback)
-inline fun Container.clipContainer(width: Int, height: Int, callback: ClipContainer.() -> Unit = {}) =
+inline fun Container.clipContainer(width: Int, height: Int, callback: @ViewDslMarker ClipContainer.() -> Unit = {}) =
     clipContainer(width.toDouble(), height.toDouble(), callback)
-inline fun Container.clipContainer(width: Double, height: Double, callback: ClipContainer.() -> Unit = {}) =
+inline fun Container.clipContainer(width: Double, height: Double, callback: @ViewDslMarker ClipContainer.() -> Unit = {}) =
     ClipContainer(width, height).addTo(this, callback)
 
 open class ClipContainer(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Container.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Container.kt
@@ -7,7 +7,7 @@ import com.soywiz.korge.render.*
 import com.soywiz.korma.geom.*
 
 /** Creates a new [Container], allowing to configure with [callback], and attaches the newly created container to the receiver this [Container] */
-inline fun Container.container(callback: Container.() -> Unit = {}) =
+inline fun Container.container(callback: @ViewDslMarker Container.() -> Unit = {}) =
 	Container().addTo(this, callback)
 
 // For Flash compatibility
@@ -232,5 +232,5 @@ operator fun View?.plusAssign(view: View?) {
 	if (view != null) container?.addChild(view)
 }
 
-inline fun <T : View> T.addTo(instance: Container, callback: T.() -> Unit = {}) =
+inline fun <T : View> T.addTo(instance: Container, callback: @ViewDslMarker T.() -> Unit = {}) =
     this.addTo(instance).apply(callback)

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Ellipse.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Ellipse.kt
@@ -14,7 +14,7 @@ inline fun Container.ellipse(
     radiusY: Double = 16.0,
     color: RGBA = Colors.WHITE,
     autoScaling: Boolean = true,
-    callback: Ellipse.() -> Unit = {}
+    callback: @ViewDslMarker Ellipse.() -> Unit = {}
 ): Ellipse = Ellipse(radiusX, radiusY, color, autoScaling).addTo(this, callback)
 
 /**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/FixedSizeContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/FixedSizeContainer.kt
@@ -5,14 +5,14 @@ import com.soywiz.korge.render.*
 import com.soywiz.korio.util.*
 import com.soywiz.korma.geom.*
 
-inline fun Container.fixedSizeContainer(width: Double, height: Double, clip: Boolean = false, callback: FixedSizeContainer.() -> Unit = {}) =
+inline fun Container.fixedSizeContainer(width: Double, height: Double, clip: Boolean = false, callback: @ViewDslMarker FixedSizeContainer.() -> Unit = {}) =
     FixedSizeContainer(width, height, clip).addTo(this, callback)
 
-inline fun Container.fixedSizeContainer(width: Int, height: Int, clip: Boolean = false, callback: FixedSizeContainer.() -> Unit = {}) =
+inline fun Container.fixedSizeContainer(width: Int, height: Int, clip: Boolean = false, callback: @ViewDslMarker FixedSizeContainer.() -> Unit = {}) =
     FixedSizeContainer(width.toDouble(), height.toDouble(), clip).addTo(this, callback)
 
 @Deprecated("Kotlin/Native boxes inline+Number")
-inline fun Container.fixedSizeContainer(width: Number, height: Number, clip: Boolean = false, callback: FixedSizeContainer.() -> Unit = {}) =
+inline fun Container.fixedSizeContainer(width: Number, height: Number, clip: Boolean = false, callback: @ViewDslMarker FixedSizeContainer.() -> Unit = {}) =
     fixedSizeContainer(width.toDouble(), height.toDouble(), clip, callback)
 
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Graphics.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Graphics.kt
@@ -8,12 +8,13 @@ import com.soywiz.korim.bitmap.*
 import com.soywiz.korim.color.*
 import com.soywiz.korim.vector.*
 import com.soywiz.korim.vector.paint.*
+import com.soywiz.korma.annotations.*
 import com.soywiz.korma.geom.*
 import com.soywiz.korma.geom.vector.*
 import kotlin.jvm.*
 
-inline fun Container.graphics(autoScaling: Boolean = false, callback: Graphics.() -> Unit = {}): Graphics = Graphics(autoScaling).addTo(this, callback)
-inline fun Container.sgraphics(callback: Graphics.() -> Unit = {}): Graphics = Graphics(autoScaling = true).addTo(this, callback)
+inline fun Container.graphics(autoScaling: Boolean = false, callback: @ViewDslMarker Graphics.() -> Unit = {}): Graphics = Graphics(autoScaling).addTo(this, callback)
+inline fun Container.sgraphics(callback: @ViewDslMarker Graphics.() -> Unit = {}): Graphics = Graphics(autoScaling = true).addTo(this, callback)
 
 open class Graphics @JvmOverloads constructor(
     var autoScaling: Boolean = false
@@ -101,11 +102,11 @@ open class Graphics @JvmOverloads constructor(
 	override fun moveTo(x: Double, y: Double) { currentPath.moveTo(x, y) }
 	override fun quadTo(cx: Double, cy: Double, ax: Double, ay: Double) { currentPath.quadTo(cx, cy, ax, ay) }
 
-    inline fun fill(color: RGBA, alpha: Double = 1.0, callback: VectorBuilder.() -> Unit) = fill(toColorFill(color, alpha), callback)
+    inline fun fill(color: RGBA, alpha: Double = 1.0, callback: @ViewDslMarker VectorBuilder.() -> Unit) = fill(toColorFill(color, alpha), callback)
     @Deprecated("Kotlin/Native boxes inline+Number")
-    inline fun fill(color: RGBA, alpha: Number, callback: VectorBuilder.() -> Unit) = fill(color, alpha.toDouble(), callback)
+    inline fun fill(color: RGBA, alpha: Number, callback: @ViewDslMarker VectorBuilder.() -> Unit) = fill(color, alpha.toDouble(), callback)
 
-	inline fun fill(paint: Paint, callback: VectorBuilder.() -> Unit) {
+	inline fun fill(paint: Paint, callback: @ViewDslMarker VectorBuilder.() -> Unit) {
 		beginFill(paint)
 		try {
 			callback()
@@ -115,7 +116,7 @@ open class Graphics @JvmOverloads constructor(
 	}
 
 	inline fun stroke(
-		color: RGBA, info: Context2d.StrokeInfo, callback: VectorBuilder.() -> Unit
+		color: RGBA, info: Context2d.StrokeInfo, callback: @ViewDslMarker VectorBuilder.() -> Unit
 	) = stroke(
 		ColorPaint(color),
 		info, callback
@@ -124,7 +125,7 @@ open class Graphics @JvmOverloads constructor(
 	inline fun stroke(
 		paint: Paint,
 		info: Context2d.StrokeInfo,
-		callback: VectorBuilder.() -> Unit
+		callback: @ViewDslMarker VectorBuilder.() -> Unit
 	) {
 		beginStroke(paint, info)
 		try {
@@ -138,7 +139,7 @@ open class Graphics @JvmOverloads constructor(
 		fill: Paint,
 		stroke: Paint,
 		strokeInfo: Context2d.StrokeInfo,
-		callback: VectorBuilder.() -> Unit
+		callback: @ViewDslMarker VectorBuilder.() -> Unit
 	) {
 		beginFillStroke(fill, stroke, strokeInfo)
 		try {

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Image.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Image.kt
@@ -4,11 +4,11 @@ import com.soywiz.korim.bitmap.*
 import com.soywiz.korma.geom.vector.*
 
 inline fun Container.image(
-	texture: BmpSlice, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: Image.() -> Unit = {}
+	texture: BmpSlice, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: @ViewDslMarker Image.() -> Unit = {}
 ): Image = Image(texture, anchorX, anchorY).addTo(this, callback)
 
 inline fun Container.image(
-	texture: Bitmap, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: Image.() -> Unit = {}
+	texture: Bitmap, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: @ViewDslMarker Image.() -> Unit = {}
 ): Image = Image(texture, anchorX, anchorY).addTo(this, callback)
 
 //typealias Sprite = Image

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatch.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatch.kt
@@ -7,7 +7,7 @@ import kotlin.math.*
 
 inline fun Container.ninePatch(
 	tex: BmpSlice, width: Double, height: Double, left: Double, top: Double, right: Double, bottom: Double,
-	callback: NinePatch.() -> Unit = {}
+	callback: @ViewDslMarker NinePatch.() -> Unit = {}
 ) = NinePatch(tex, width, height, left, top, right, bottom).addTo(this, callback)
 
 class NinePatch(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatchEx.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatchEx.kt
@@ -6,12 +6,12 @@ import com.soywiz.korim.bitmap.*
 import com.soywiz.korma.geom.*
 
 inline fun Container.ninePatch(
-	tex: NinePatchEx.Tex, width: Double, height: Double, callback: NinePatchEx.() -> Unit
+	tex: NinePatchEx.Tex, width: Double, height: Double, callback: @ViewDslMarker NinePatchEx.() -> Unit
 ) = NinePatchEx(tex, width, height).addTo(this, callback)
 
 inline fun Container.ninePatch(
 	ninePatch: NinePatchBitmap32, width: Double = ninePatch.dwidth, height: Double = ninePatch.dheight,
-	callback: NinePatchEx.() -> Unit
+	callback: @ViewDslMarker NinePatchEx.() -> Unit
 ) = NinePatchEx(ninePatch, width, height).addTo(this, callback)
 
 class NinePatchEx(

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/RoundRect.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/RoundRect.kt
@@ -16,7 +16,7 @@ inline fun Container.roundRect(
     ry: Number = rx,
     color: RGBA = Colors.WHITE,
     autoScaling: Boolean = true,
-    callback: RoundRect.() -> Unit = {}
+    callback: @ViewDslMarker RoundRect.() -> Unit = {}
 ) = roundRect(width.toDouble(), height.toDouble(), rx.toDouble(), ry.toDouble(), color, autoScaling, callback)
 
 inline fun Container.roundRect(
@@ -26,7 +26,7 @@ inline fun Container.roundRect(
     ry: Double = rx,
     color: RGBA = Colors.WHITE,
     autoScaling: Boolean = true,
-    callback: RoundRect.() -> Unit = {}
+    callback: @ViewDslMarker RoundRect.() -> Unit = {}
 ) = RoundRect(width, height, rx, ry, color, autoScaling).addTo(this, callback)
 
 /**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/ScaleView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/ScaleView.kt
@@ -4,7 +4,7 @@ import com.soywiz.korge.render.*
 
 inline fun Container.scaleView(
 	width: Int, height: Int, scale: Double = 2.0, filtering: Boolean = false,
-	callback: Container.() -> Unit = {}
+	callback: @ViewDslMarker Container.() -> Unit = {}
 ) = ScaleView(width, height, scale, filtering).addTo(this, callback)
 
 class ScaleView(width: Int, height: Int, scale: Double = 2.0, var filtering: Boolean = false) :

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/SolidRect.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/SolidRect.kt
@@ -4,13 +4,13 @@ import com.soywiz.korim.color.*
 
 /** Creates a new [SolidRect] of size [width]x[height] and color [color] and allows you to configure it via [callback]. Once created, it is added to this receiver [Container]. */
 @Deprecated("Kotlin/Native boxes inline+Number")
-inline fun Container.solidRect(width: Number, height: Number, color: RGBA, callback: SolidRect.() -> Unit = {})
+inline fun Container.solidRect(width: Number, height: Number, color: RGBA, callback: @ViewDslMarker SolidRect.() -> Unit = {})
     = solidRect(width.toDouble(), height.toDouble(), color, callback)
 
-inline fun Container.solidRect(width: Double, height: Double, color: RGBA, callback: SolidRect.() -> Unit = {})
+inline fun Container.solidRect(width: Double, height: Double, color: RGBA, callback: @ViewDslMarker SolidRect.() -> Unit = {})
     = SolidRect(width, height, color).addTo(this, callback)
 
-inline fun Container.solidRect(width: Int, height: Int, color: RGBA, callback: SolidRect.() -> Unit = {})
+inline fun Container.solidRect(width: Int, height: Int, color: RGBA, callback: @ViewDslMarker SolidRect.() -> Unit = {})
     = SolidRect(width.toDouble(), height.toDouble(), color).addTo(this, callback)
 
 /**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Sprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Sprite.kt
@@ -7,15 +7,15 @@ import com.soywiz.korio.async.Signal
 import com.soywiz.korma.geom.vector.VectorPath
 
 inline fun Container.sprite(
-    initialAnimation: SpriteAnimation, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: Sprite.() -> Unit = {}
+    initialAnimation: SpriteAnimation, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: @ViewDslMarker Sprite.() -> Unit = {}
 ): Sprite = Sprite(initialAnimation, anchorX, anchorY).addTo(this, callback)
 
 inline fun Container.sprite(
-    texture: BmpSlice = Bitmaps.white, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: Sprite.() -> Unit = {}
+    texture: BmpSlice = Bitmaps.white, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: @ViewDslMarker Sprite.() -> Unit = {}
 ): Sprite = Sprite(texture, anchorX, anchorY).addTo(this, callback)
 
 inline fun Container.sprite(
-    texture: Bitmap, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: Sprite.() -> Unit = {}
+    texture: Bitmap, anchorX: Double = 0.0, anchorY: Double = 0.0, callback: @ViewDslMarker Sprite.() -> Unit = {}
 ): Sprite = Sprite(texture, anchorX, anchorY).addTo(this, callback)
 
 /**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Text.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Text.kt
@@ -14,7 +14,7 @@ inline fun Container.text(
 	textSize: Double = 16.0,
 	color: RGBA = Colors.WHITE,
 	font: BitmapFont = Fonts.defaultFont,
-	callback: Text.() -> Unit = {}
+	callback: @ViewDslMarker Text.() -> Unit = {}
 ) = Text(text, textSize = textSize, color = color, font = font).addTo(this, callback)
 
 class Text : View(), IText, IHtml {

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Text2.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Text2.kt
@@ -33,7 +33,7 @@ inline fun Container.text2(
     color: RGBA = Colors.WHITE, font: Font = DefaultTtfFont,
     horizontalAlign: HorizontalAlign = HorizontalAlign.LEFT, verticalAlign: VerticalAlign = VerticalAlign.TOP,
     noinline renderer: TextRenderer<String> = DefaultStringTextRenderer,
-    block: Text2.() -> Unit = {}
+    block: @ViewDslMarker Text2.() -> Unit = {}
 ): Text2
     = Text2(text, fontSize, color, font, horizontalAlign, verticalAlign, renderer).addTo(this, block)
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/View.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/View.kt
@@ -55,7 +55,6 @@ typealias DisplayObject = View
  * For views with [Updatable] components, [View] include a [speed] property where 1 is 1x and 2 is 2x the speed.
  */
 @OptIn(KorgeInternal::class)
-@KorDslMarker
 abstract class View internal constructor(
     /** Indicates if this class is a container or not. This is only overrided by Container. This check is performed like this, to avoid type checks. That might be an expensive operation in some targets. */
     val isContainer: Boolean
@@ -1586,11 +1585,7 @@ inline fun <T : View> T.position(point: IPoint): T = position(point.x, point.y)
 inline fun <T : View> T.visible(visible: Boolean): T = this.also { it.visible = visible }
 inline fun <T : View> T.name(name: String?): T = this.also { it.name = name }
 
-@DslMarker
-@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
-annotation class VectorBuilderDslMarker
-
-inline fun <T : View> T.hitShape(crossinline block: @VectorBuilderDslMarker VectorBuilder.() -> Unit): T {
+inline fun <T : View> T.hitShape(crossinline block: @ViewDslMarker VectorBuilder.() -> Unit): T {
     buildPath { block() }.also {
         this.hitShape = it
     }
@@ -1891,3 +1886,7 @@ inline fun <T : View> T.alignBottomToTopOf(other: View, padding: Number): T =
 @Deprecated("Kotlin/Native boxes inline+Number")
 inline fun <T : View> T.alignBottomToBottomOf(other: View, padding: Number): T =
     alignBottomToBottomOf(other, padding.toDouble())
+
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS) annotation class ViewDslMarker
+// @TODO: This causes issues having to put some explicit this@ when it shouldn't be required
+//typealias ViewDslMarker = KorDslMarker

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
@@ -13,10 +13,10 @@ import com.soywiz.korim.color.*
 import com.soywiz.korma.geom.*
 import kotlin.math.*
 
-inline fun Container.tileMap(map: IntArray2, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, callback: TileMap.() -> Unit = {}) =
+inline fun Container.tileMap(map: IntArray2, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, callback: @ViewDslMarker TileMap.() -> Unit = {}) =
 	TileMap(map, tileset).repeat(repeatX, repeatY).addTo(this, callback)
 
-inline fun Container.tileMap(map: Bitmap32, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, callback: TileMap.() -> Unit = {}) =
+inline fun Container.tileMap(map: Bitmap32, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, callback: @ViewDslMarker TileMap.() -> Unit = {}) =
 	TileMap(map.toIntArray2(), tileset).repeat(repeatX, repeatY).addTo(this, callback)
 
 @OptIn(KorgeInternal::class)


### PR DESCRIPTION
Created an annotation that now is a dummy annotation but that can be changed to an typealias for KorDslMarker so we can switch to it fast and check stuff

Fixes #262