### PR TITLE
Add timePerFrame to SpriteAnimation's companion invoke

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/SpriteAnimation.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/SpriteAnimation.kt
@@ -21,12 +21,13 @@ class SpriteAnimation(
             columns: Int = 1,
             rows: Int = 1,
             offsetBetweenColumns: Int = 0,
-            offsetBetweenRows: Int = 0
+            offsetBetweenRows: Int = 0,
+            timePerFrame: TimeSpan = TimeSpan.NULL
         ): SpriteAnimation {
             return SpriteAnimation(
                 ArrayList<BmpSlice>().apply {
-                    for (row in 0 until rows){
-                        for (col in 0 until columns){
+                    for (row in 0 until rows) {
+                        for (col in 0 until columns) {
                             add(
                                 spriteMap.sliceWithSize(
                                     marginLeft + (spriteWidth + offsetBetweenColumns) * col,
@@ -38,7 +39,8 @@ class SpriteAnimation(
                             )
                         }
                     }
-                }
+                },
+                timePerFrame
             )
         }
     }


### PR DESCRIPTION
SpriteAnimation's companion invoke was the only way to create a SpriteAnimation without a way to set the frametime. This just adds it in.