### PR TITLE
Add onCollisionExit extension functions to View

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/ViewCollision.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/ViewCollision.kt
@@ -132,3 +132,61 @@ fun View.onDescendantCollision(root: View = this, filterSrc: (View) -> Boolean =
 		}
 	}
 }
+
+/**
+ * Adds a component to [this] that checks each frame for collisions against descendant views of [root] that matches the [filter],
+ * when a collision is found, it remembers it and the next time the collision does not occur, [callback] is executed with this view as receiver, 
+ * and the collision target as first parameter. if no [root] is provided, it computes the root of the view [this] each frame, you can specify a collision [kind]
+ */
+fun View.onCollisionExit(
+    filter: (View) -> Boolean = { true },
+    root: View? = null,
+    kind: CollisionKind = CollisionKind.GLOBAL_RECT,
+    callback: View.(View) -> Unit
+): Cancellable {
+    val collisionState = mutableMapOf<View, Boolean>()
+    return addUpdater {
+        (root ?: this.root).foreachDescendant {
+            if (this != it && filter(it)) {
+                if (this.collidesWith(it, kind)) {
+                    collisionState[it] = true
+                } else if (collisionState[it] == true) {
+                    callback(this, it)
+                    collisionState[it] = false
+                }
+            }
+        }
+    }
+}
+
+fun View.onCollisionShapeExit(filter: (View) -> Boolean = { true }, root: View? = null, callback: View.(View) -> Unit): Cancellable {
+    return onCollisionExit(filter, root, kind = CollisionKind.SHAPE, callback = callback)
+}
+
+fun List<View>.onCollisionExit(filter: (View) -> Boolean = { true }, root: View? = null, kind: CollisionKind = CollisionKind.GLOBAL_RECT, callback: View.(View) -> Unit): Cancellable =
+    Cancellable(this.map { it.onCollisionExit(filter, root, kind, callback) })
+
+/**
+ * Adds a component to [this] that checks collisions each frame of descendants views of [root] matching [filterSrc], matching against descendant views matching [filterDst].
+ * When a collision is found, it remembers it and the next time the collision does not occur, [callback] is called. It returns a [Cancellable] to remove the component.
+ */
+fun View.onDescendantCollisionExit(root: View = this, filterSrc: (View) -> Boolean = { true }, filterDst: (View) -> Boolean = { true }, kind: CollisionKind = CollisionKind.GLOBAL_RECT, callback: View.(View) -> Unit): Cancellable {
+    val collisionState = mutableMapOf<Pair<View, View>, Boolean>()
+    return addUpdater {
+        root.foreachDescendant { src ->
+            if (filterSrc(src)) {
+                root.foreachDescendant { dst ->
+                    if (src !== dst && filterDst(dst)) {
+                        if (src.collidesWith(dst, kind)) {
+                            println("collide")
+                            collisionState[Pair(src, dst)] = true
+                        } else if (collisionState[Pair(src, dst)] == true) {
+                            callback(src, dst)
+                            collisionState[Pair(src, dst)] = false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello, this is my first open source PR so feel free to tell me if I'm doing something wrong here.

I use Unity a lot and I thought Korge lacked a collision exiting function. I think this is really useful to avoid using hitTest inside an updater to do it manually, and you cannot use shapes with this method.
Example case : detecting when a player is falling down a platform

I hope you'll consider it :blush: