### PR TITLE
[#307] Make Animator3D handle single Animation

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge3d/animation/Animator3D.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge3d/animation/Animator3D.kt
@@ -1,78 +1,74 @@
 package com.soywiz.korge3d.animation
 
 import com.soywiz.kds.*
-import com.soywiz.kds.iterators.*
 import com.soywiz.klock.*
-import com.soywiz.korge.internal.*
 import com.soywiz.korge3d.*
 import com.soywiz.korma.geom.*
 import com.soywiz.korma.interpolation.*
 
 @Korge3DExperimental
-class Animator3D(val animations: List<Animation3D>, val rootView: View3D) {
+class Animator3D(val animation: Animation3D, val rootView: View3D) {
 	var currentTime = 0.milliseconds
 	fun update(dt: TimeSpan) {
 		//currentTime += ms.ms * 0.1
 		currentTime += dt
-		animations.fastForEach { animation ->
-			val keyFrames = animation.keyFrames
-			val fseconds = keyFrames.seconds
-			val ftransforms = keyFrames.transforms
-			val ffloats = keyFrames.floats
-			val aproperty = animation.property
-			val elapsedTimeInAnimation = (currentTime % animation.totalTime)
-			//genericBinarySearch(0, animation.keys.size) { animation.keys[it] }
+		val keyFrames = animation.keyFrames
+		val fseconds = keyFrames.seconds
+		val ftransforms = keyFrames.transforms
+		val ffloats = keyFrames.floats
+		val aproperty = animation.property
+		val elapsedTimeInAnimation = (currentTime % animation.totalTime)
+		//genericBinarySearch(0, animation.keys.size) { animation.keys[it] }
 
-			val n = keyFrames.findIndex(elapsedTimeInAnimation)
-			if (n < 0) return@fastForEach
+		val n = keyFrames.findIndex(elapsedTimeInAnimation)
+		if (n < 0) return
 
-			val startTime = fseconds[n].toDouble().seconds
-			val endTime = fseconds.getOrNull(n + 1)?.let { it.toDouble().seconds } ?: startTime
-			val fragmentTime = (endTime - startTime)
-			if (fragmentTime <= 0.milliseconds) return@fastForEach
+		val startTime = fseconds[n].toDouble().seconds
+		val endTime = fseconds.getOrNull(n + 1)?.let { it.toDouble().seconds } ?: startTime
+		val fragmentTime = (endTime - startTime)
+		if (fragmentTime <= 0.milliseconds) return
 
-			val ratio = (elapsedTimeInAnimation - startTime) / fragmentTime
-			val aview = rootView[animation.target]
-			//println("ratio: $ratio, startTime=$startTime, endTime=$endTime, elapsedTimeInAnimation=$elapsedTimeInAnimation")
-			if (aview != null) {
-				when (aproperty) {
-					"transform" -> {
-						if (ftransforms != null) {
-							if (n >= ftransforms.size) {
-								error("Unexpected")
-							}
-							aview.transform.setToInterpolated(
-								ftransforms[n],
-								ftransforms.getCyclic(n + 1),
-								ratio.toDouble()
-							)
+		val ratio = (elapsedTimeInAnimation - startTime) / fragmentTime
+		val aview = rootView[animation.target]
+		//println("ratio: $ratio, startTime=$startTime, endTime=$endTime, elapsedTimeInAnimation=$elapsedTimeInAnimation")
+		if (aview != null) {
+			when (aproperty) {
+				"transform" -> {
+					if (ftransforms != null) {
+						if (n >= ftransforms.size) {
+							error("Unexpected")
 						}
-					}
-					"location.X", "location.Y", "location.Z", "scale.X", "scale.Y", "scale.Z", "rotationX.ANGLE", "rotationY.ANGLE", "rotationZ.ANGLE" -> {
-						if (ffloats != null) {
-							val value = ratio.interpolate(ffloats[n], ffloats[n % ffloats.size]).toDouble()
-							when (aproperty) {
-								"location.X" -> aview.x = value
-								"location.Y" -> aview.y = value
-								"location.Z" -> aview.z = value
-								"scale.X" -> aview.scaleX = value
-								"scale.Y" -> aview.scaleY = value
-								"scale.Z" -> aview.scaleZ = value
-								"rotationX.ANGLE" -> aview.rotationX = value.degrees
-								"rotationY.ANGLE" -> aview.rotationY = value.degrees
-								"rotationZ.ANGLE" -> aview.rotationZ = value.degrees
-							}
-						}
-					}
-					else -> {
-						println("WARNING: animation.property=${animation.property} not implemented")
+						aview.transform.setToInterpolated(
+							ftransforms[n],
+							ftransforms.getCyclic(n + 1),
+							ratio.toDouble()
+						)
 					}
 				}
+				"location.X", "location.Y", "location.Z", "scale.X", "scale.Y", "scale.Z", "rotationX.ANGLE", "rotationY.ANGLE", "rotationZ.ANGLE" -> {
+					if (ffloats != null) {
+						val value = ratio.interpolate(ffloats[n], ffloats[n % ffloats.size]).toDouble()
+						when (aproperty) {
+							"location.X" -> aview.x = value
+							"location.Y" -> aview.y = value
+							"location.Z" -> aview.z = value
+							"scale.X" -> aview.scaleX = value
+							"scale.Y" -> aview.scaleY = value
+							"scale.Z" -> aview.scaleZ = value
+							"rotationX.ANGLE" -> aview.rotationX = value.degrees
+							"rotationY.ANGLE" -> aview.rotationY = value.degrees
+							"rotationZ.ANGLE" -> aview.rotationZ = value.degrees
+						}
+					}
+				}
+				else -> {
+					println("WARNING: animation.property=${animation.property} not implemented")
+				}
 			}
-
-			//animation.keyFrames.binarySearch { it.time.millisecondsInt }
-			//println(animation)
 		}
+
+		//animation.keyFrames.binarySearch { it.time.millisecondsInt }
+		//println(animation)
 	}
 }
 

--- a/korge/src/jvmTest/kotlin/com/soywiz/korge/korge3d/main.kt
+++ b/korge/src/jvmTest/kotlin/com/soywiz/korge/korge3d/main.kt
@@ -176,9 +176,9 @@ object Demo3 {
 			//mainSceneView.rotation(90.degrees, 0.degrees, 0.degrees)
 
 
-			val animator = Animator3D(library.animationDefs.values, mainSceneView)
+			val animators = library.animationDefs.values.map { Animator3D(it, mainSceneView) }
             addUpdater {
-				animator.update(it)
+				animators.forEach { animator -> animator.update(it) }
 			}
 
 			val camera1 = cameras.firstOrNull() ?: camera


### PR DESCRIPTION
Currently for 3D animations it's only possible to play a collection
of them in a loop, with regular speed. The goal of this change is to
prepare the API for more fine-grained control over a single animation:
customizing playback speed, reversing playback, setting arbitrary progress
and more. That's why I recommend changing Animator3D's API to handle
a single animation instead of a collection.

I'm planning to extend the API as described above in the subsequent commits,
and would like this breaking change to go as a separate PR for better
visibility. Further changes will be backward-compatible.

This is a breaking API change, but given that KorGE 3D is still
experimental, I presume it's fine to just mention it in the release
notes. See a change in `korge/src/jvmTest/kotlin/com/soywiz/korge/korge3d/main.kt`
for a migration example.