### PR TITLE
Fix UiHorizontalStack width calculation

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIContainerLayouts.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIContainerLayouts.kt
@@ -67,7 +67,7 @@ open class UIHorizontalStack(height: Double = UI_DEFAULT_HEIGHT, padding: Double
             it.scaledHeight = height
             x += it.width + padding
         }
-        width = y
+        width = x
     }
 }
 


### PR DESCRIPTION
Fix of a mistake in setting width for **horizontal** stack

This bug makes `UiHorizontalStack` absolutely broken and useless