### PR TITLE
Update README to mention korge-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ in addition to ensure the continuity of the project, you will get exclusive cont
 
 <https://korge.org>
 
+Note: active development of korge is currently being done in the [korge-next](https://github.com/korlibs/korge-next) monorepo. Please check there for the latest releases and code.
+
 ## Contributors
 
 ### Code Contributors


### PR DESCRIPTION
When newcomers find the korge repo with all of the stars and issues, it can be off-putting to think that there have been no changes or releases for almost a year. Updating the readme to mention active development in korge-next can help alleviate this issue.