### PR TITLE
fix Matrix3D.setToLookAt bug

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Matrix3D.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Matrix3D.kt
@@ -949,7 +949,7 @@ fun Matrix3D.setToLookAt(
         x.x, y.x, z.x, 0f,
         x.y, y.y, z.y, 0f,
         x.z, y.z, z.z, 0f,
-        0f, 0f, 0f, 1f
+        -x.dot(eye), -y.dot(eye), -z.dot(eye), 1f
     )
 }
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dxmatrixlookatlh?redirectedfrom=MSDN#remarks

zaxis = normal(At - Eye)
xaxis = normal(cross(Up, zaxis))
yaxis = cross(zaxis, xaxis)

 xaxis.x           yaxis.x           zaxis.x          0
 xaxis.y           yaxis.y           zaxis.y          0
 xaxis.z           yaxis.z           zaxis.z          0
-dot(xaxis, eye)  -dot(yaxis, eye)  -dot(zaxis, eye)  1