### PR TITLE
Fix/fixes.gpu.vector.rendering

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/render/BatchBuilder2D.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/render/BatchBuilder2D.kt
@@ -742,7 +742,7 @@ class BatchBuilder2D constructor(
         val u_OutputPre: Uniform = Uniform("u_OutputPre", VarType.Bool1)
         val u_TexN: Array<Uniform> = Array(BB_MAX_TEXTURES) { Uniform("u_Tex$it", VarType.Sampler2D) }
 
-        fun DO_INPUT_ENSURE_TO(builder: Program.Builder, out: Operand, premultiplied: Boolean) {
+        fun DO_INPUT_ENSURE_TO(builder: Program.Builder, out: Operand, premultiplied: Boolean, v_InputPre: Operand = BatchBuilder2D.v_InputPre) {
             builder.apply {
                 if (premultiplied) {
                     // We want premultiplied, but input was straight
@@ -758,7 +758,7 @@ class BatchBuilder2D constructor(
             }
         }
 
-        fun DO_OUTPUT_FROM(builder: Program.Builder, out: Operand, premultiplied: Boolean) {
+        fun DO_OUTPUT_FROM(builder: Program.Builder, out: Operand, premultiplied: Boolean, u_OutputPre: Operand = BatchBuilder2D.u_OutputPre) {
             builder.apply {
                 if (premultiplied) {
                     // We come from premultiplied, but output wants straight

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/vector/GpuShapeViewCommands.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/vector/GpuShapeViewCommands.kt
@@ -4,6 +4,7 @@ import com.soywiz.kds.FastArrayList
 import com.soywiz.kds.fastArrayListOf
 import com.soywiz.kds.floatArrayListOf
 import com.soywiz.kds.iterators.fastForEach
+import com.soywiz.kmem.toInt
 import com.soywiz.korag.AG
 import com.soywiz.korag.DefaultShaders
 import com.soywiz.korag.disableCullFace
@@ -193,13 +194,13 @@ class GpuShapeViewCommands {
                                                 tempUniforms.put(GpuShapeViewPrograms.u_GlobalPixelScale, pixelScale)
 
                                                 val texUnit = tempUniforms[DefaultShaders.u_Tex] as? AG.TextureUnit?
-                                                //val premultiplied = texUnit?.texture?.premultiplied ?: false
+                                                val premultiplied = texUnit?.texture?.premultiplied ?: false
                                                 //val premultiplied = false
                                                 val outPremultiplied = ag.isRenderingToTexture
 
                                                 //println("outPremultiplied=$outPremultiplied, blendMode=${cmd.blendMode?.name}")
 
-                                                //tempUniforms[BatchBuilder2D.u_InputPre] = premultiplied
+                                                tempUniforms[GpuShapeViewPrograms.u_InputPre] = premultiplied.toInt().toFloat()
                                                 tempUniforms[BatchBuilder2D.u_OutputPre] = outPremultiplied
 
                                                 list.uboSet(ubo, tempUniforms)

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/vector/GpuShapeViewPrograms.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/vector/GpuShapeViewPrograms.kt
@@ -30,6 +30,7 @@ import kotlin.math.PI
 
 @KorgeInternal
 object GpuShapeViewPrograms {
+    val u_InputPre = Uniform("u_InputPre", VarType.Float1)
     val u_ProgramType = Uniform("u_ProgramType", VarType.Float1)
     //val u_LineWidth = Uniform("u_LineWidth", VarType.Float1)
     val u_Color = Uniform("u_Color", VarType.Float4)
@@ -150,7 +151,7 @@ object GpuShapeViewPrograms {
             }
 
             // Colors are premultiplied
-            BatchBuilder2D.DO_INPUT_ENSURE_TO(this, out, premultiplied = true)
+            BatchBuilder2D.DO_INPUT_ENSURE_TO(this, out, premultiplied = true, v_InputPre = u_InputPre)
 
             // Update global alpha
             val aaAlpha = 1f.lit - smoothstep(v_MaxDist * u_GlobalPixelScale - 1.5f.lit, v_MaxDist * u_GlobalPixelScale, abs(v_Dist * u_GlobalPixelScale))

--- a/korge/src/jvmTest/resources/korge/render/GpuShapeView.log
+++ b/korge/src/jvmTest/resources/korge/render/GpuShapeView.log
@@ -5,7 +5,7 @@ RenderBuffer[1].setSize(200, 200)
 RenderBuffer[1].set()
 clear(#00000000, 1.0, 0, true, true, true)
 createBuffer():6
-programCreate: 1, Program(name=GpuShapeViewPrograms.Combined, attributes=[a_Pos, a_Dist, a_MaxDist], uniforms=[u_ProjMat, u_ViewMat, u_ProgramType, u_Color, u_Tex, u_Transform, u_Gradientp0, u_Gradientp1, u_ColorMul, u_GlobalAlpha, u_GlobalPixelScale, u_OutputPre]), ProgramConfig(externalTextureSampler=false)
+programCreate: 1, Program(name=GpuShapeViewPrograms.Combined, attributes=[a_Pos, a_Dist, a_MaxDist], uniforms=[u_ProjMat, u_ViewMat, u_ProgramType, u_Color, u_Tex, u_Transform, u_Gradientp0, u_Gradientp1, u_InputPre, u_ColorMul, u_GlobalAlpha, u_GlobalPixelScale, u_OutputPre]), ProgramConfig(externalTextureSampler=false)
 programCreate.fragment:#version 100 compatibility
 #ifdef GL_ES
 	precision highp float;
@@ -23,6 +23,7 @@ uniform sampler2D u_Tex;
 uniform mat4 u_Transform;
 uniform vec3 u_Gradientp0;
 uniform vec3 u_Gradientp1;
+uniform float u_InputPre;
 uniform vec4 u_ColorMul;
 uniform float u_GlobalAlpha;
 uniform float u_GlobalPixelScale;
@@ -30,7 +31,6 @@ uniform bool u_OutputPre;
 varying mediump float v_Dist;
 varying mediump float v_MaxDist;
 varying mediump vec2 v_Tex;
-varying lowp float v_InputPre;
 void main() {
 	vec2 temp3;
 	vec4 temp0;
@@ -79,7 +79,7 @@ void main() {
 			}
 		}
 	}
-	if ((v_InputPre == 0.0)) {
+	if ((u_InputPre == 0.0)) {
 		gl_FragColor.rgb = (gl_FragColor.rgb * gl_FragColor.a);
 	}
 	gl_FragColor = (gl_FragColor * u_ColorMul);
@@ -152,6 +152,7 @@ scissor: -788, -1188, 536, 536
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -175,6 +176,7 @@ draw: TRIANGLE_FAN, offset=0, count=7, instances=1, indexType=null
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -198,6 +200,7 @@ draw: TRIANGLE_FAN, offset=0, count=7, instances=1, indexType=null
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -221,6 +224,7 @@ draw: TRIANGLE_FAN, offset=7, count=7, instances=1, indexType=null
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -247,6 +251,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (0, 0, 1)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -276,6 +281,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (0, 0, 1)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -305,6 +311,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (0, 0, 1)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -332,6 +339,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (1, 1, 0)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 disable: STENCIL
@@ -907,6 +915,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (1, 0, 0)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 disable: STENCIL
@@ -949,6 +958,7 @@ uboSet.uniform: Uniform(u_Transform) = Matrix3D(
 uboSet.uniform: Uniform(u_GlobalAlpha) = 0.75
 uboSet.uniform: Uniform(u_Tex) = TextureUnit(texture=Texture[0], linear=true, trilinear=null)
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 1.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 disable: STENCIL
@@ -978,6 +988,7 @@ scissor: -1900, -780, 808, 800
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -1001,6 +1012,7 @@ draw: TRIANGLE_FAN, offset=624, count=7, instances=1, indexType=null
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -1024,6 +1036,7 @@ draw: TRIANGLE_FAN, offset=624, count=7, instances=1, indexType=null
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -1741,6 +1754,7 @@ draw: TRIANGLE_FAN, offset=631, count=701, instances=1, indexType=null
 uboSet: 2
 uboSet.uniform: Uniform(u_ProgramType) = 5.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -2471,6 +2485,7 @@ uboSet.uniform: Uniform(u_Gradientp1) = (100, 100, 0)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 0.9
 uboSet.uniform: Uniform(u_Tex) = TextureUnit(texture=Texture[1], linear=true, trilinear=null)
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 1.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 enable: STENCIL
@@ -2509,6 +2524,7 @@ uboSet.uniform: Uniform(u_Gradientp1) = (130, 180, 70)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 0.9
 uboSet.uniform: Uniform(u_Tex) = TextureUnit(texture=Texture[2], linear=true, trilinear=null)
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 1.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 disable: STENCIL
@@ -2549,6 +2565,7 @@ uboSet.uniform: Uniform(u_Gradientp1) = (0, 0, 0)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 0.9
 uboSet.uniform: Uniform(u_Tex) = TextureUnit(texture=Texture[3], linear=true, trilinear=null)
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 2.0
+uboSet.uniform: Uniform(u_InputPre) = 1.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 disable: STENCIL

--- a/korge/src/jvmTest/resources/korge/render/GpuShapeViewFilter.log
+++ b/korge/src/jvmTest/resources/korge/render/GpuShapeViewFilter.log
@@ -25,6 +25,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (1, 1, 1)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 0.6
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = true
 uboUse: 2
 uboDelete: 2

--- a/korge/src/jvmTest/resources/korge/render/Graphics.log
+++ b/korge/src/jvmTest/resources/korge/render/Graphics.log
@@ -148,7 +148,7 @@ draw: TRIANGLES, offset=0, count=6, instances=1, indexType=USHORT
 vaoUse: 0
 vaoDelete: 1
 createBuffer():6
-programCreate: 2, Program(name=GpuShapeViewPrograms.Combined, attributes=[a_Pos, a_Dist, a_MaxDist], uniforms=[u_ProjMat, u_ViewMat, u_ProgramType, u_Color, u_Tex, u_Transform, u_Gradientp0, u_Gradientp1, u_ColorMul, u_GlobalAlpha, u_GlobalPixelScale, u_OutputPre]), ProgramConfig(externalTextureSampler=false)
+programCreate: 2, Program(name=GpuShapeViewPrograms.Combined, attributes=[a_Pos, a_Dist, a_MaxDist], uniforms=[u_ProjMat, u_ViewMat, u_ProgramType, u_Color, u_Tex, u_Transform, u_Gradientp0, u_Gradientp1, u_InputPre, u_ColorMul, u_GlobalAlpha, u_GlobalPixelScale, u_OutputPre]), ProgramConfig(externalTextureSampler=false)
 programCreate.fragment:#version 100 compatibility
 #ifdef GL_ES
 	precision highp float;
@@ -166,6 +166,7 @@ uniform sampler2D u_Tex;
 uniform mat4 u_Transform;
 uniform vec3 u_Gradientp0;
 uniform vec3 u_Gradientp1;
+uniform float u_InputPre;
 uniform vec4 u_ColorMul;
 uniform float u_GlobalAlpha;
 uniform float u_GlobalPixelScale;
@@ -173,7 +174,6 @@ uniform bool u_OutputPre;
 varying mediump float v_Dist;
 varying mediump float v_MaxDist;
 varying mediump vec2 v_Tex;
-varying lowp float v_InputPre;
 void main() {
 	vec2 temp3;
 	vec4 temp0;
@@ -222,7 +222,7 @@ void main() {
 			}
 		}
 	}
-	if ((v_InputPre == 0.0)) {
+	if ((u_InputPre == 0.0)) {
 		gl_FragColor.rgb = (gl_FragColor.rgb * gl_FragColor.a);
 	}
 	gl_FragColor = (gl_FragColor * u_ColorMul);
@@ -297,6 +297,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (1, 0, 0)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 0.5
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = false
 uboUse: 2
 disable: STENCIL
@@ -1210,6 +1211,7 @@ uboSet.uniform: Uniform(u_ProgramType) = 0.0
 uboSet.uniform: Uniform(u_Color) = (0, 0, 1)
 uboSet.uniform: Uniform(u_GlobalAlpha) = 1.0
 uboSet.uniform: Uniform(u_GlobalPixelScale) = 0.5
+uboSet.uniform: Uniform(u_InputPre) = 0.0
 uboSet.uniform: Uniform(u_OutputPre) = false
 uboUse: 2
 disable: STENCIL

--- a/korge/src/jvmTest/resources/korge/render/OpenGLShapeView.log
+++ b/korge/src/jvmTest/resources/korge/render/OpenGLShapeView.log
@@ -7,6 +7,7 @@ uniform sampler2D u_Tex;
 uniform mat4 u_Transform;
 uniform vec3 u_Gradientp0;
 uniform vec3 u_Gradientp1;
+uniform float u_InputPre;
 uniform vec4 u_ColorMul;
 uniform float u_GlobalAlpha;
 uniform float u_GlobalPixelScale;
@@ -14,7 +15,6 @@ uniform bool u_OutputPre;
 varying float v_Dist;
 varying float v_MaxDist;
 varying vec2 v_Tex;
-varying float v_InputPre;
 void main() {
 	vec2 temp3;
 	vec4 temp0;
@@ -63,7 +63,7 @@ void main() {
 			}
 		}
 	}
-	if ((v_InputPre == 0.0)) {
+	if ((u_InputPre == 0.0)) {
 		gl_FragColor.rgb = (gl_FragColor.rgb * gl_FragColor.a);
 	}
 	gl_FragColor = (gl_FragColor * u_ColorMul);
@@ -147,6 +147,8 @@ getUniformLocation(1001, "u_GlobalAlpha") = 7011
 uniform1f(7011, 1.0)
 getUniformLocation(1001, "u_GlobalPixelScale") = 7012
 uniform1f(7012, 10.0)
+getUniformLocation(1001, "u_InputPre") = 7013
+uniform1f(7013, 0.0)
 uniform1i(7007, 0)
 disable(2960)
 stencilMask(0)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/gl/AGQueueProcessorOpenGL.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/gl/AGQueueProcessorOpenGL.kt
@@ -544,6 +544,7 @@ class AGQueueProcessorOpenGL(
                 VarType.Float1, VarType.Float2, VarType.Float3, VarType.Float4 -> {
                     var arrayCount = declArrayCount
                     when (value) {
+                        is Boolean ->tempBuffer.setFloat(0, value.toInt().toFloat())
                         is Number -> tempBuffer.setAlignedFloat32(0, value.toFloat())
                         is Vector3D -> tempBuffer.setFloats(0, value.data, 0, stride)
                         is FloatArray -> {


### PR DESCRIPTION
To avoid further regressions we should do addition e2e rendering tests for other features other than filters like gpu vector rendering, tilemaps, etc.: https://github.com/korlibs/korge/issues/853