### PR TITLE
Support keeping some scene properties while hot reloading

### DIFF
--- a/korge/build.gradle
+++ b/korge/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	add("commonMainApi", project(":korau"))
 	add("commonMainApi", project(":korinject"))
     commonMainApi(project(":korte"))
+    jvmMainApi("org.jetbrains.kotlin:kotlin-reflect")
     //add("jvmMainApi", project(":korte"))
 
 	//add("commonTestApi", "it.krzeminski.vis-assert:vis-assert:0.4.0-beta")

--- a/korge/build.gradle
+++ b/korge/build.gradle
@@ -15,6 +15,9 @@ dependencies {
 	add("commonMainApi", project(":korinject"))
     commonMainApi(project(":korte"))
     jvmMainApi("org.jetbrains.kotlin:kotlin-reflect")
+    jvmMainApi("com.fasterxml.jackson.core:jackson-databind:2.13.3")
+    jvmMainApi("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
+
     //add("jvmMainApi", project(":korte"))
 
 	//add("commonTestApi", "it.krzeminski.vis-assert:vis-assert:0.4.0-beta")

--- a/korge/src/androidMain/kotlin/com/soywiz/korge/KorgeReload_getReloadedClass.kt
+++ b/korge/src/androidMain/kotlin/com/soywiz/korge/KorgeReload_getReloadedClass.kt
@@ -1,7 +1,4 @@
 package com.soywiz.korge
 
-import kotlin.reflect.*
-
-internal actual fun <T : Any> KorgeReload_getReloadedClass(clazz: KClass<T>, context: ReloadClassContext): KClass<T> {
-    return clazz
+internal actual val KorgeReloadInternal: KorgeReloadInternalImpl = object : KorgeReloadInternalImpl() {
 }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/debug/UiEditProperties.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/debug/UiEditProperties.kt
@@ -11,17 +11,22 @@ import com.soywiz.korui.scrollPanel
 
 class UiEditProperties(app: UiApplication, view: View?, val views: Views) : UiContainer(app) {
     val propsContainer = scrollPanel(xbar = false)
+    var currentView: View? = null
 
     fun setView(view: View?) {
-        propsContainer.removeChildren()
-
-        view?.buildDebugComponent(views, this@UiEditProperties.propsContainer)
+        setViewBase(view)
 
         root?.updateUI()
         root?.relayout()
         root?.repaintAll()
 
         update()
+    }
+
+    fun setViewBase(view: View?) {
+        propsContainer.removeChildren()
+        currentView = view
+        view?.buildDebugComponent(views, this@UiEditProperties.propsContainer)
     }
 
     private val registeredProperties = WeakMap<ObservableProperty<*>, Boolean>()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/scene/SceneContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/scene/SceneContainer.kt
@@ -91,11 +91,21 @@ class SceneContainer(
                 val scene = currentScene
                 if (scene != null) {
                     println("[ReloadEvent] Reloading $currentScene . doFullReload=${event.doFullReload}")
-                    if (event.doFullReload) {
-                        changeTo(event.getReloadedClass(scene::class, scene.injector))
+                    val sceneClass: KClass<Scene> = if (event.doFullReload) {
+                        event.getReloadedClass(scene::class, scene.injector)
                     } else {
-                        changeTo(scene::class)
-                    }
+                        scene::class
+                    } as KClass<Scene>
+
+                    changeTo(sceneClass, {
+                        it.get(sceneClass).also { newScene ->
+                            try {
+                                event.transferKeepProperties(scene, newScene)
+                            } catch (e: Throwable) {
+                                e.printStackTrace()
+                            }
+                        }
+                    })
                 }
             }
         }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/scene/SceneContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/scene/SceneContainer.kt
@@ -97,15 +97,17 @@ class SceneContainer(
                         scene::class
                     } as KClass<Scene>
 
-                    changeTo(sceneClass, {
-                        it.get(sceneClass).also { newScene ->
-                            try {
-                                event.transferKeepProperties(scene, newScene)
-                            } catch (e: Throwable) {
-                                e.printStackTrace()
+                    val scene = changeTo(sceneClass, {
+                        it.get(sceneClass)
+                            .also { newScene ->
+                                try {
+                                    event.transferKeepProperties(scene, newScene)
+                                } catch (e: Throwable) {
+                                    e.printStackTrace()
+                                }
                             }
-                        }
                     })
+                    scene.views.debugHightlightView(scene.sceneView)
                 }
             }
         }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/ViewDebugExtra.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/ViewDebugExtra.kt
@@ -1,0 +1,30 @@
+package com.soywiz.korge.view
+
+import com.soywiz.kds.Extra
+import com.soywiz.kds.FastArrayList
+import com.soywiz.korge.debug.uiCollapsibleSection
+import com.soywiz.korui.UiContainer
+
+class DebugExtraComponents(val view: View) {
+    val sections = LinkedHashMap<String, FastArrayList<UiContainer.() -> Unit>>()
+
+    init {
+        view.extraBuildDebugComponent = { views, view, container ->
+            for ((section, callbacks) in sections) {
+                container.uiCollapsibleSection(section) {
+                    for (callback in callbacks) callback()
+                }
+            }
+        }
+    }
+
+    fun add(section: String, block: UiContainer.() -> Unit) {
+        sections.getOrPut(section) { FastArrayList() }.add(block)
+    }
+}
+
+val View.debugExtraComponents: DebugExtraComponents by Extra.PropertyThis { DebugExtraComponents(this) }
+
+fun View.addDebugExtraComponent(section: String, block: UiContainer.() -> Unit) {
+    debugExtraComponents.add(section, block)
+}

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/view/ViewDebugTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/view/ViewDebugTest.kt
@@ -1,0 +1,16 @@
+package com.soywiz.korge.view
+
+import com.soywiz.korge.debug.uiEditableValue
+import kotlin.test.Test
+
+class ViewDebugTest {
+    var myprop = 10.0
+
+    @Test
+    fun test() {
+        val view = DummyView()
+        view.addDebugExtraComponent("Debug") {
+            uiEditableValue(::myprop)
+        }
+    }
+}

--- a/korge/src/jsMain/kotlin/com/soywiz/korge/KorgeReload_getReloadedClass.kt
+++ b/korge/src/jsMain/kotlin/com/soywiz/korge/KorgeReload_getReloadedClass.kt
@@ -1,7 +1,4 @@
 package com.soywiz.korge
 
-import kotlin.reflect.*
-
-internal actual fun <T : Any> KorgeReload_getReloadedClass(clazz: KClass<T>, context: ReloadClassContext): KClass<T> {
-    return clazz
+internal actual val KorgeReloadInternal: KorgeReloadInternalImpl = object : KorgeReloadInternalImpl() {
 }

--- a/korge/src/jvmMain/kotlin/com/soywiz/korge/KorgeExtJvm.kt
+++ b/korge/src/jvmMain/kotlin/com/soywiz/korge/KorgeExtJvm.kt
@@ -1,12 +1,13 @@
 package com.soywiz.korge
 
 import com.soywiz.klock.milliseconds
-import com.soywiz.korge.awt.*
-import com.soywiz.korge.time.*
-import com.soywiz.korge.view.*
-import com.soywiz.korui.*
-import com.soywiz.korui.native.*
-import kotlinx.coroutines.*
+import com.soywiz.korge.awt.ViewsDebuggerComponent
+import com.soywiz.korge.time.timers
+import com.soywiz.korge.view.Views
+import com.soywiz.korge.view.views
+import com.soywiz.korui.UiApplication
+import com.soywiz.korui.native.DEFAULT_UI_FACTORY
+import kotlinx.coroutines.runBlocking
 import java.awt.Container
 
 internal actual fun completeViews(views: Views) {
@@ -21,7 +22,7 @@ internal actual fun completeViews(views: Views) {
         frame.add(debugger)
         views.stage.timers.interval(500.milliseconds) {
             if (views.gameWindow.debug) {
-                debugger.update()
+                debugger.updateTimer()
             }
         }
         debugger

--- a/korge/src/jvmMain/kotlin/com/soywiz/korge/KorgeReload_getReloadedClass.kt
+++ b/korge/src/jvmMain/kotlin/com/soywiz/korge/KorgeReload_getReloadedClass.kt
@@ -4,15 +4,38 @@ import com.soywiz.korinject.jvmAutomapping
 import com.soywiz.korinject.jvmRemoveMappingsByClassName
 import java.io.File
 import kotlin.reflect.*
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.memberProperties
 
-internal actual fun <T : Any> KorgeReload_getReloadedClass(clazz: KClass<T>, context: ReloadClassContext): KClass<T> {
-    println("### KorgeReload_getReloadedClass: $clazz")
-    val oldClass = clazz
-    val newClass = KorgeReloadClassLoader().loadClass(oldClass.qualifiedName).kotlin as KClass<T>
-    context.injector.jvmRemoveMappingsByClassName(context.refreshedClasses)
-    context.injector.removeMapping(oldClass)
-    context.injector.root.jvmAutomapping()
-    return newClass
+internal actual val KorgeReloadInternal: KorgeReloadInternalImpl = object : KorgeReloadInternalImpl() {
+    override fun <T : Any> getReloadedClass(clazz: KClass<T>, context: ReloadClassContext): KClass<T> {
+        println("### KorgeReload_getReloadedClass: $clazz")
+        val oldClass = clazz
+        val newClass = KorgeReloadClassLoader().loadClass(oldClass.qualifiedName).kotlin as KClass<T>
+        context.injector.jvmRemoveMappingsByClassName(context.refreshedClasses)
+        context.injector.removeMapping(oldClass)
+        context.injector.root.jvmAutomapping()
+        return newClass
+    }
+
+    override fun transferKeepProperties(old: Any, new: Any) {
+        //println("transferKeepProperties: ${old::class.java}")
+        for (prop in old::class.memberProperties) {
+            if (prop.hasAnnotation<KeepOnReload>()) {
+                //println("- $prop : ${prop.annotations}")
+                try {
+                    val newProp = new::class.memberProperties.firstOrNull { it.name == prop.name }
+                    if (newProp != null && newProp.hasAnnotation<KeepOnReload>()) {
+                        val oldValue = (prop as KProperty1<Any, Any>).get(old)
+                        //println("   ** Trying to set $oldValue to $newProp")
+                        (newProp as KMutableProperty1<Any, Any>).set(new, oldValue)
+                    }
+                } catch (e: Throwable) {
+                    e.printStackTrace()
+                }
+            }
+        }
+    }
 }
 
 class KorgeReloadClassLoader(

--- a/korge/src/nativeMain/kotlin/com/soywiz/korge/KorgeReloadNative.kt
+++ b/korge/src/nativeMain/kotlin/com/soywiz/korge/KorgeReloadNative.kt
@@ -1,7 +1,4 @@
 package com.soywiz.korge
 
-import kotlin.reflect.KClass
-
-internal actual fun <T : Any> KorgeReload_getReloadedClass(clazz: KClass<T>, context: ReloadClassContext): KClass<T> {
-    return clazz
+internal actual val KorgeReloadInternal: KorgeReloadInternalImpl = object : KorgeReloadInternalImpl() {
 }


### PR DESCRIPTION
```kotlin
class MyScene : Scene() {
    @KeepOnReload var textSize = 100.0 // If this value is modified at runtime, the new value will be persisted if we hotreload the scene. Effectively making modifying this value when compiling a no-op until the app is closed and reopened. You can also remove the annotation to modify again the value by code.

    @KeepOnReload var positionX by Delegates.observable(50.0) { _, _, _ -> reload() } // It even works with delegates! So we can register it later.

   // Also when a scene is reloaded the SContainer view will be highlighted, so the debug components will appear
   fun SContainer.sceneMain() {
      // Now we can add a debug component and use the views debugger to manually adjust properties that will be persisted later
      extraBuildDebugComponent = { views, view, container ->
        container.uiCollapsibleSection("Debug") {
            uiEditableValue(::textSize)
            uiEditableValue(::positionX, min = 0.0, max = 100.0, clamp = true)
        }
     }
   }
}
```