### PR TITLE
Support scalable vector shapes with 9-patch, NinePatchShape and NinePatchShapeView

### DIFF
--- a/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
+++ b/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
@@ -3,37 +3,35 @@ package samples
 import com.soywiz.korge.scene.Scene
 import com.soywiz.korge.view.SContainer
 import com.soywiz.korge.view.addUpdater
-import com.soywiz.korge.view.graphics
+import com.soywiz.korge.view.ninePatchShapeView
 import com.soywiz.korim.color.Colors
 import com.soywiz.korim.util.NinePatchSlices
-import com.soywiz.korim.util.NinePatchSlices2D
-import com.soywiz.korim.vector.NinePatchVector
-import com.soywiz.korma.geom.Size
+import com.soywiz.korim.vector.buildShape
+import com.soywiz.korim.vector.ninePatch
 import com.soywiz.korma.geom.range.until
-import com.soywiz.korma.geom.shape.buildVectorPath
+import com.soywiz.korma.geom.vector.rect
 import com.soywiz.korma.geom.vector.roundRect
-import com.soywiz.korma.geom.vector.write
 
 class MainVectorNinePatch : Scene() {
     val mouseX get() = sceneView.localMouseX(views)
     val mouseY get() = sceneView.localMouseY(views)
 
     override suspend fun SContainer.sceneMain() {
-        val vector = buildVectorPath {
-            roundRect(0, 0, 300, 300, 75, 75)
-        }
-        val vector9 = NinePatchVector(vector, NinePatchSlices2D(
+        val view = ninePatchShapeView(buildShape {
+            fill(Colors.RED) {
+                roundRect(0, 0, 300, 300, 75, 75)
+                rect(0, 225, 75, 75)
+            }
+            fill(Colors.WHITE) {
+                roundRect(10, 10, 300 - 20, 300 - 20, 45, 45)
+            }
+        }.ninePatch(
             NinePatchSlices(77.0 until (300.0 - 77.0)),
             NinePatchSlices(77.0 until (300.0 - 77.0)),
         ))
-        val g = graphics()
 
         addUpdater {
-            g.updateShape {
-                fill(Colors.WHITE) {
-                    write(vector9.transform(Size(mouseX, mouseY)))
-                }
-            }
+            view.setSize(mouseX, mouseY)
         }
     }
 }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatchShapeView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatchShapeView.kt
@@ -1,0 +1,36 @@
+package com.soywiz.korge.view
+
+import com.soywiz.korge.ui.UIView
+import com.soywiz.korim.vector.NinePatchShape
+import com.soywiz.korma.geom.Size
+
+inline fun Container.ninePatchShapeView(
+    shape: NinePatchShape,
+    renderer: GraphicsRenderer = GraphicsRenderer.SYSTEM,
+    callback: @ViewDslMarker NinePatchShapeView.() -> Unit = {}
+): NinePatchShapeView = NinePatchShapeView(shape, renderer).addTo(this, callback)
+
+class NinePatchShapeView(
+    shape: NinePatchShape,
+    renderer: GraphicsRenderer,
+) : UIView(shape.size.width, shape.size.height) {
+    private val graphics = graphics(shape.shape, renderer = renderer)
+    var boundsIncludeStrokes: Boolean by graphics::boundsIncludeStrokes
+    var antialiased: Boolean by graphics::antialiased
+    var smoothing: Boolean by graphics::smoothing
+    var autoScaling: Boolean by graphics::autoScaling
+    var anchorX: Double by graphics::anchorX
+    var anchorY: Double by graphics::anchorY
+    var renderer: GraphicsRenderer by graphics::renderer
+
+    var shape: NinePatchShape = shape
+        set(value) {
+            if (field == value) return
+            field = value
+            onSizeChanged()
+        }
+
+    override fun onSizeChanged() {
+        graphics.shape = shape.transform(Size(width, height))
+    }
+}

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
@@ -1,0 +1,29 @@
+package com.soywiz.korim.vector
+
+import com.soywiz.korim.util.NinePatchSlices
+import com.soywiz.korim.util.NinePatchSlices2D
+import com.soywiz.korma.geom.ISize
+import com.soywiz.korma.geom.asSize
+import com.soywiz.korma.geom.bottomRight
+
+class NinePatchShape(val shape: Shape, val slices: NinePatchSlices2D) {
+    val size: ISize = shape.bounds.bottomRight.asSize()
+
+    fun transform(newSize: ISize): Shape {
+        return shape.scaleNinePatch(newSize, slices)
+    }
+
+    private fun Shape.scaleNinePatch(newSize: ISize, slices: NinePatchSlices2D, oldSize: ISize? = this.bounds.bottomRight.asSize()): Shape {
+        return when (this) {
+            EmptyShape -> EmptyShape
+            is CompoundShape -> CompoundShape(this.components.map { it.scaleNinePatch(newSize, slices, oldSize) })
+            is FillShape -> FillShape(path.scaleNinePatch(newSize, slices, oldSize), clip?.scaleNinePatch(newSize, slices, oldSize), paint, transform, globalAlpha)
+            is PolylineShape -> PolylineShape(path.scaleNinePatch(newSize, slices, oldSize), clip?.scaleNinePatch(newSize, slices, oldSize), paint, transform, strokeInfo, globalAlpha)
+            is TextShape -> TextShape(text, x, y, font, fontSize, clip?.scaleNinePatch(newSize, slices, oldSize), fill, stroke, halign, valign, transform, globalAlpha)
+            else -> TODO()
+        }
+    }
+}
+
+fun Shape.ninePatch(slices: NinePatchSlices2D): NinePatchShape = NinePatchShape(this, slices)
+fun Shape.ninePatch(x: NinePatchSlices, y: NinePatchSlices): NinePatchShape = NinePatchShape(this, NinePatchSlices2D(x, y))

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchVector.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchVector.kt
@@ -6,9 +6,13 @@ import com.soywiz.korma.geom.PointArrayList
 import com.soywiz.korma.geom.Size
 import com.soywiz.korma.geom.vector.VectorPath
 
-class NinePatchVector(val path: VectorPath, val slices: NinePatchSlices2D) {
+class NinePatchVector(
+    val path: VectorPath,
+    val slices: NinePatchSlices2D,
+    oldSize: ISize? = null
+) {
     private val pathBounds = path.getBounds()
-    private val oldSize = Size(pathBounds.right, pathBounds.bottom)
+    private val oldSize = oldSize ?: Size(pathBounds.right, pathBounds.bottom)
     private val tempPoints = PointArrayList()
 
     private inline fun transform(newSize: ISize, gen: PointArrayList.() -> Unit): PointArrayList {
@@ -45,7 +49,7 @@ class NinePatchVector(val path: VectorPath, val slices: NinePatchSlices2D) {
     }
 }
 
-fun VectorPath.scaleNinePatch(newSize: ISize, slices: NinePatchSlices2D = NinePatchSlices2D(), out: VectorPath = VectorPath()): VectorPath {
+fun VectorPath.scaleNinePatch(newSize: ISize, slices: NinePatchSlices2D = NinePatchSlices2D(), oldSize: ISize? = null, out: VectorPath = VectorPath()): VectorPath {
     out.clear()
-    return NinePatchVector(this, slices).transform(newSize, out)
+    return NinePatchVector(this, slices, oldSize).transform(newSize, out)
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Shape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Shape.kt
@@ -412,7 +412,7 @@ data class PolylineShape constructor(
 	)
 }
 
-class CompoundShape(
+open class CompoundShape(
 	val components: List<Shape>
 ) : Shape {
 	override fun addBounds(bb: BoundsBuilder, includeStrokes: Boolean) { components.fastForEach { it.addBounds(bb, includeStrokes)}  }

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Size.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Size.kt
@@ -23,6 +23,9 @@ interface ISize {
     }
 }
 
+fun Point.asSize(): Size = Size(this)
+fun IPoint.asSize(): ISize = Size(Point(this))
+
 inline class Size(val p: Point) : MutableInterpolable<Size>, Interpolable<Size>, ISize, Sizeable {
     companion object {
         operator fun invoke(): Size = Size(Point(0, 0))


### PR DESCRIPTION
https://user-images.githubusercontent.com/99644907/190603955-7a14c874-da9a-4ea6-89e7-ba9cba5b41b6.mov

```kotlin
class MainVectorNinePatch : Scene() {
    val mouseX get() = sceneView.localMouseX(views)
    val mouseY get() = sceneView.localMouseY(views)

    override suspend fun SContainer.sceneMain() {
        val view = ninePatchShapeView(buildShape {
            fill(Colors.RED) {
                roundRect(0, 0, 300, 300, 75, 75)
                rect(0, 225, 75, 75)
            }
            fill(Colors.WHITE) {
                roundRect(10, 10, 300 - 20, 300 - 20, 45, 45)
            }
        }.ninePatch(
            NinePatchSlices(77.0 until (300.0 - 77.0)),
            NinePatchSlices(77.0 until (300.0 - 77.0)),
        ))

        addUpdater {
            view.setSize(mouseX, mouseY)
        }
    }
}
```