### PR TITLE
Support loading SVG files with guides that act as 9-patches

### DIFF
--- a/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
+++ b/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
@@ -6,7 +6,7 @@ import com.soywiz.korge.view.addUpdater
 import com.soywiz.korge.view.ninePatchShapeView
 import com.soywiz.korim.color.Colors
 import com.soywiz.korim.vector.format.readSVG
-import com.soywiz.korim.vector.toNinePatchWithGuides
+import com.soywiz.korim.vector.toNinePatchFromGuides
 import com.soywiz.korim.vector.toShape
 import com.soywiz.korio.file.std.resourcesVfs
 
@@ -19,7 +19,7 @@ class MainVectorNinePatch : Scene() {
             resourcesVfs["chat-bubble.svg"]
                 .readSVG()
                 .toShape()
-                .toNinePatchWithGuides(guideColor = Colors.FUCHSIA)
+                .toNinePatchFromGuides(guideColor = Colors.FUCHSIA)
         )
 
         //graphics(resourcesVfs["chat-bubble.svg"].readSVG().toShape())

--- a/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
+++ b/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
@@ -5,30 +5,31 @@ import com.soywiz.korge.view.SContainer
 import com.soywiz.korge.view.addUpdater
 import com.soywiz.korge.view.ninePatchShapeView
 import com.soywiz.korim.color.Colors
-import com.soywiz.korim.util.NinePatchSlices
-import com.soywiz.korim.vector.buildShape
-import com.soywiz.korim.vector.ninePatch
-import com.soywiz.korma.geom.range.until
-import com.soywiz.korma.geom.vector.rect
-import com.soywiz.korma.geom.vector.roundRect
+import com.soywiz.korim.vector.format.readSVG
+import com.soywiz.korim.vector.toNinePatchWithGuides
+import com.soywiz.korim.vector.toShape
+import com.soywiz.korio.file.std.resourcesVfs
 
 class MainVectorNinePatch : Scene() {
     val mouseX get() = sceneView.localMouseX(views)
     val mouseY get() = sceneView.localMouseY(views)
 
     override suspend fun SContainer.sceneMain() {
-        val view = ninePatchShapeView(buildShape {
-            fill(Colors.RED) {
-                roundRect(0, 0, 300, 300, 75, 75)
-                rect(0, 225, 75, 75)
-            }
-            fill(Colors.WHITE) {
-                roundRect(10, 10, 300 - 20, 300 - 20, 45, 45)
-            }
-        }.ninePatch(
-            NinePatchSlices(77.0 until (300.0 - 77.0)),
-            NinePatchSlices(77.0 until (300.0 - 77.0)),
-        ))
+        val view = ninePatchShapeView(resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchWithGuides(color = Colors.FUCHSIA))
+        //graphics(resourcesVfs["chat-bubble.svg"].readSVG().toShape())
+        //return
+        //val view = ninePatchShapeView(buildShape {
+        //    fill(Colors.RED) {
+        //        roundRect(0, 0, 300, 300, 75, 75)
+        //        rect(0, 225, 75, 75)
+        //    }
+        //    fill(Colors.WHITE) {
+        //        roundRect(10, 10, 300 - 20, 300 - 20, 45, 45)
+        //    }
+        //}.ninePatch(
+        //    NinePatchSlices(77.0 until (300.0 - 77.0)),
+        //    NinePatchSlices(77.0 until (300.0 - 77.0)),
+        //))
 
         addUpdater {
             view.setSize(mouseX, mouseY)

--- a/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
+++ b/korge-sandbox/src/commonMain/kotlin/samples/MainVectorNinePatch.kt
@@ -15,7 +15,13 @@ class MainVectorNinePatch : Scene() {
     val mouseY get() = sceneView.localMouseY(views)
 
     override suspend fun SContainer.sceneMain() {
-        val view = ninePatchShapeView(resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchWithGuides(color = Colors.FUCHSIA))
+        val view = ninePatchShapeView(
+            resourcesVfs["chat-bubble.svg"]
+                .readSVG()
+                .toShape()
+                .toNinePatchWithGuides(guideColor = Colors.FUCHSIA)
+        )
+
         //graphics(resourcesVfs["chat-bubble.svg"].readSVG().toShape())
         //return
         //val view = ninePatchShapeView(buildShape {

--- a/korge-sandbox/src/commonMain/resources/chat-bubble.svg
+++ b/korge-sandbox/src/commonMain/resources/chat-bubble.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <path d="M128,27.646C128,12.388 115.612,0 100.354,0L27.646,0C12.388,0 0,12.388 0,27.646L0,82.938C0,98.196 12.388,110.584 27.646,110.584L38.372,110.584L34.482,128L76.145,110.584L100.354,110.584C115.612,110.584 128,98.196 128,82.938L128,27.646Z" style="fill:rgb(235,235,235);"/>
+    <g id="_9-patch" serif:id="9-patch">
+        <path d="M30,128L30,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <g transform="matrix(1,0,0,1,3,0)">
+            <path d="M30,128L30,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        </g>
+        <path d="M0.5,40L128,40" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <path d="M0,80L128,80" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <path d="M80,128L80,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <path d="M100,128L100,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+    </g>
+</svg>

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/util/NinePatchSlices.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/util/NinePatchSlices.kt
@@ -2,10 +2,18 @@ package com.soywiz.korim.util
 
 import com.soywiz.kds.DoubleArrayList
 import com.soywiz.korma.geom.range.DoubleRangeExclusive
+import com.soywiz.korma.geom.range.until
 
 class NinePatchSlices private constructor(val ranges: List<DoubleRangeExclusive>, dummy: Unit) {
     constructor(ranges: List<DoubleRangeExclusive>) : this(ranges.sortedBy { it.start }, Unit)
     constructor(vararg ranges: DoubleRangeExclusive) : this(ranges.sortedBy { it.start }, Unit)
+    companion object {
+        operator fun invoke(vararg doubles: Double): NinePatchSlices {
+            if (doubles.size % 2 != 0) error("Number of slices must be pair")
+            return NinePatchSlices((0 until (doubles.size / 2)).map { doubles[it * 2] until doubles[it * 2 + 1] })
+        }
+    }
+
     val lengths get() = ranges.sumOf { it.length }
 
     // @TODO: newLen < oldLen should make corners (non-stretch areas) smaller
@@ -43,4 +51,7 @@ class NinePatchSlices private constructor(val ranges: List<DoubleRangeExclusive>
     fun transform1D(input: List<DoubleArrayList>, oldLen: Double, newLen: Double): List<DoubleArrayList> =
         input.map { transform1D(it, oldLen, newLen) }
 
+    override fun hashCode(): Int = ranges.hashCode()
+    override fun equals(other: Any?): Boolean = other is NinePatchSlices && this.ranges == other.ranges
+    override fun toString(): String = "NinePatchSlices(${ranges.joinToString(", ")})"
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/util/NinePatchSlices2D.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/util/NinePatchSlices2D.kt
@@ -5,7 +5,7 @@ import com.soywiz.korma.geom.PointArrayList
 import kotlin.math.absoluteValue
 import kotlin.math.sign
 
-class NinePatchSlices2D(val x: NinePatchSlices, val y: NinePatchSlices) {
+data class NinePatchSlices2D(val x: NinePatchSlices, val y: NinePatchSlices) {
     constructor() : this(NinePatchSlices(), NinePatchSlices())
     fun transform2DInplace(
         positions: PointArrayList, oldSize: ISize, newSize: ISize,

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
@@ -1,7 +1,6 @@
 package com.soywiz.korim.vector
 
 import com.soywiz.kds.fastArrayListOf
-import com.soywiz.kds.mapDouble
 import com.soywiz.korim.color.Colors
 import com.soywiz.korim.color.RGBA
 import com.soywiz.korim.util.NinePatchSlices
@@ -34,7 +33,7 @@ fun Shape.ninePatch(slices: NinePatchSlices2D): NinePatchShape = NinePatchShape(
 fun Shape.ninePatch(x: NinePatchSlices, y: NinePatchSlices): NinePatchShape = NinePatchShape(this, NinePatchSlices2D(x, y))
 
 
-fun Shape.toNinePatchWithGuides(color: RGBA = Colors.FUCHSIA, optimizeShape: Boolean = true): NinePatchShape {
+fun Shape.toNinePatchWithGuides(guideColor: RGBA = Colors.FUCHSIA, optimizeShape: Boolean = true): NinePatchShape {
     val guides = fastArrayListOf<VectorPath>()
     fun Shape.getShapeWithoutGuidesAndPopulateGuides(): Shape {
         return when (this) {
@@ -44,7 +43,7 @@ fun Shape.toNinePatchWithGuides(color: RGBA = Colors.FUCHSIA, optimizeShape: Boo
                     .filter { it !is EmptyShape }
             )
             is PolylineShape -> {
-                if (this.paint == color) {
+                if (this.paint == guideColor) {
                     guides += this.path
                     EmptyShape
                 } else {

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
@@ -1,10 +1,15 @@
 package com.soywiz.korim.vector
 
+import com.soywiz.kds.fastArrayListOf
+import com.soywiz.kds.mapDouble
+import com.soywiz.korim.color.Colors
+import com.soywiz.korim.color.RGBA
 import com.soywiz.korim.util.NinePatchSlices
 import com.soywiz.korim.util.NinePatchSlices2D
 import com.soywiz.korma.geom.ISize
 import com.soywiz.korma.geom.asSize
 import com.soywiz.korma.geom.bottomRight
+import com.soywiz.korma.geom.vector.VectorPath
 
 class NinePatchShape(val shape: Shape, val slices: NinePatchSlices2D) {
     val size: ISize = shape.bounds.bottomRight.asSize()
@@ -27,3 +32,38 @@ class NinePatchShape(val shape: Shape, val slices: NinePatchSlices2D) {
 
 fun Shape.ninePatch(slices: NinePatchSlices2D): NinePatchShape = NinePatchShape(this, slices)
 fun Shape.ninePatch(x: NinePatchSlices, y: NinePatchSlices): NinePatchShape = NinePatchShape(this, NinePatchSlices2D(x, y))
+
+
+fun Shape.toNinePatchWithGuides(color: RGBA = Colors.FUCHSIA, optimizeShape: Boolean = true): NinePatchShape {
+    val guides = fastArrayListOf<VectorPath>()
+    fun Shape.getShapeWithoutGuidesAndPopulateGuides(): Shape {
+        return when (this) {
+            is CompoundShape -> CompoundShape(
+                this.components
+                    .map { it.getShapeWithoutGuidesAndPopulateGuides() }
+                    .filter { it !is EmptyShape }
+            )
+            is PolylineShape -> {
+                if (this.paint == color) {
+                    guides += this.path
+                    EmptyShape
+                } else {
+                    this
+                }
+            }
+            else -> this
+        }
+    }
+
+    val shapeWithoutGuides = getShapeWithoutGuidesAndPopulateGuides().let { if (optimizeShape) it.optimize() else it }
+    val guidesBounds = guides.map { it.getBounds() }
+    val horizontalSlices = guidesBounds.filter { it.height > it.width }.map { it.x }.sorted().toDoubleArray()
+    val verticalSlices = guidesBounds.filter { it.width > it.height }.map { it.y }.sorted().toDoubleArray()
+    if (verticalSlices.size % 2 != 0) error("Vertical guides are not a pair number")
+    if (horizontalSlices.size % 2 != 0) error("Horizontal guides are not a pair number")
+    val slices = NinePatchSlices2D(
+        NinePatchSlices(*horizontalSlices),
+        NinePatchSlices(*verticalSlices),
+    )
+    return NinePatchShape(shapeWithoutGuides, slices)
+}

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/NinePatchShape.kt
@@ -33,7 +33,7 @@ fun Shape.ninePatch(slices: NinePatchSlices2D): NinePatchShape = NinePatchShape(
 fun Shape.ninePatch(x: NinePatchSlices, y: NinePatchSlices): NinePatchShape = NinePatchShape(this, NinePatchSlices2D(x, y))
 
 
-fun Shape.toNinePatchWithGuides(guideColor: RGBA = Colors.FUCHSIA, optimizeShape: Boolean = true): NinePatchShape {
+fun Shape.toNinePatchFromGuides(guideColor: RGBA = Colors.FUCHSIA, optimizeShape: Boolean = true): NinePatchShape {
     val guides = fastArrayListOf<VectorPath>()
     fun Shape.getShapeWithoutGuidesAndPopulateGuides(): Shape {
         return when (this) {

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Shape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Shape.kt
@@ -147,6 +147,16 @@ sealed interface Shape : BoundsDrawable {
 	fun containsPoint(x: Double, y: Double): Boolean = bounds.contains(x, y)
 }
 
+fun Shape.optimize(): Shape {
+    return when (this) {
+        is CompoundShape -> {
+            val comps = this.components.filter { it !is EmptyShape }
+            if (comps.size == 1) comps.first() else CompoundShape(comps)
+        }
+        else -> this
+    }
+}
+
 fun Shape.getBounds(out: Rectangle = Rectangle(), bb: BoundsBuilder = BoundsBuilder(), includeStrokes: Boolean = false): Rectangle {
 	bb.reset()
 	addBounds(bb, includeStrokes)

--- a/korim/src/commonTest/kotlin/com/soywiz/korim/vector/NinePatchShapeTest.kt
+++ b/korim/src/commonTest/kotlin/com/soywiz/korim/vector/NinePatchShapeTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class NinePatchShapeTest {
     @Test
     fun test() = suspendTest {
-        val ninePatch = resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchWithGuides(color = Colors.FUCHSIA)
+        val ninePatch = resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchWithGuides(guideColor = Colors.FUCHSIA)
         assertEquals(Size(128, 128), ninePatch.size)
         assertEquals(NinePatchSlices2D(
             NinePatchSlices(30.0 until 33.0, 80.0 until 100.0),

--- a/korim/src/commonTest/kotlin/com/soywiz/korim/vector/NinePatchShapeTest.kt
+++ b/korim/src/commonTest/kotlin/com/soywiz/korim/vector/NinePatchShapeTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class NinePatchShapeTest {
     @Test
     fun test() = suspendTest {
-        val ninePatch = resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchWithGuides(guideColor = Colors.FUCHSIA)
+        val ninePatch = resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchFromGuides(guideColor = Colors.FUCHSIA)
         assertEquals(Size(128, 128), ninePatch.size)
         assertEquals(NinePatchSlices2D(
             NinePatchSlices(30.0 until 33.0, 80.0 until 100.0),

--- a/korim/src/commonTest/kotlin/com/soywiz/korim/vector/NinePatchShapeTest.kt
+++ b/korim/src/commonTest/kotlin/com/soywiz/korim/vector/NinePatchShapeTest.kt
@@ -1,0 +1,30 @@
+package com.soywiz.korim.vector
+
+import com.soywiz.korim.color.Colors
+import com.soywiz.korim.util.NinePatchSlices
+import com.soywiz.korim.util.NinePatchSlices2D
+import com.soywiz.korim.vector.format.readSVG
+import com.soywiz.korio.async.suspendTest
+import com.soywiz.korio.file.std.resourcesVfs
+import com.soywiz.korma.geom.Size
+import com.soywiz.korma.geom.range.until
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NinePatchShapeTest {
+    @Test
+    fun test() = suspendTest {
+        val ninePatch = resourcesVfs["chat-bubble.svg"].readSVG().toShape().toNinePatchWithGuides(color = Colors.FUCHSIA)
+        assertEquals(Size(128, 128), ninePatch.size)
+        assertEquals(NinePatchSlices2D(
+            NinePatchSlices(30.0 until 33.0, 80.0 until 100.0),
+            NinePatchSlices(40.0 until 80.0)
+        ), ninePatch.slices)
+        assertTrue { ninePatch.shape is FillShape }
+        assertEquals(
+            "M0,0 M128,28 C128,12,116,0,100,0 L28,0 C12,0,0,12,0,28 L0,83 C0,98,12,111,28,111 L38,111 L34,128 L76,111 L100,111 C116,111,128,98,128,83 L128,28 Z",
+            ninePatch.shape.getPath().roundDecimalPlaces(0).toSvgString()
+        )
+    }
+}

--- a/korim/src/commonTest/resources/chat-bubble.svg
+++ b/korim/src/commonTest/resources/chat-bubble.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <path d="M128,27.646C128,12.388 115.612,0 100.354,0L27.646,0C12.388,0 0,12.388 0,27.646L0,82.938C0,98.196 12.388,110.584 27.646,110.584L38.372,110.584L34.482,128L76.145,110.584L100.354,110.584C115.612,110.584 128,98.196 128,82.938L128,27.646Z" style="fill:rgb(235,235,235);"/>
+    <g id="_9-patch" serif:id="9-patch">
+        <path d="M30,128L30,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <g transform="matrix(1,0,0,1,3,0)">
+            <path d="M30,128L30,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        </g>
+        <path d="M0.5,40L128,40" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <path d="M0,80L128,80" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <path d="M80,128L80,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+        <path d="M100,128L100,0" style="fill:none;stroke:rgb(255,0,255);stroke-width:1px;"/>
+    </g>
+</svg>

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/range/OpenRange.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/range/OpenRange.kt
@@ -1,8 +1,11 @@
 package com.soywiz.korma.geom.range
 
+import com.soywiz.korma.internal.niceStr
+
 data class DoubleRangeExclusive(val start: Double, val endExclusive: Double) {
     val length: Double get() = endExclusive - start
     operator fun contains(value: Double): Boolean = value >= start && value < endExclusive
+    override fun toString(): String = "${start.niceStr} until ${endExclusive.niceStr}"
 }
 
 inline infix fun Double.until(endExclusive: Double): DoubleRangeExclusive = DoubleRangeExclusive(this, endExclusive)


### PR DESCRIPTION
https://user-images.githubusercontent.com/99644907/190616668-b55be7cb-39cc-4ba7-b8da-682d7ad76131.mov

So the idea here is to create a SVG file that has some strokes of a specific color (by default fuchsia #ff00ff) along the rest of the vectors. This functionality allows to read that SVG, strip those guide lines and use them as cut points for the generic 9-patch slices.

![Screenshot 2022-09-16 at 12 14 25](https://user-images.githubusercontent.com/99644907/190616682-f52bb52a-c1e4-452c-a040-a33f00c7959e.png)

```kotlin
class MainVectorNinePatch : Scene() {
    val mouseX get() = sceneView.localMouseX(views)
    val mouseY get() = sceneView.localMouseY(views)

    override suspend fun SContainer.sceneMain() {
        val view = ninePatchShapeView(
            resourcesVfs["chat-bubble.svg"]
                .readSVG()
                .toShape()
                .toNinePatchFromGuides(guideColor = Colors.FUCHSIA)
        )
        addUpdater {
            view.setSize(mouseX, mouseY)
        }
    }
}
```

Those guides can be created with any vector software that exports to SVG, as long as the color for those lines matches the guideColor in code. Those guides can be in the root node, or in any group or subgroup:

![Screenshot 2022-09-16 at 12 22 04](https://user-images.githubusercontent.com/99644907/190618073-534d592a-cad6-4305-bf04-3254098da302.png)
