### PR TITLE
[DO NOT MERGE] Create lots of fake submodules depending on the korge project to trigger project import performance

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,8 @@ kotlin {
 
 //apply(from = "${rootProject.rootDir}/build.idea.gradle")
 
-fun Project.hasBuildGradle() = listOf("build.gradle", "build.gradle.kts").any { File(projectDir, it).exists() }
+//fun Project.hasBuildGradle() = listOf("build.gradle", "build.gradle.kts").any { File(projectDir, it).exists() }
+fun Project.hasBuildGradle() = true
 val Project.isSample: Boolean get() = project.path.startsWith(":samples:") || project.path.startsWith(":korge-sandbox") || project.path.startsWith(":korge-editor") || project.path.startsWith(":korge-starter-kit")
 fun Project.mustAutoconfigureKMM(): Boolean =
     project.name != "korge-gradle-plugin" &&
@@ -1372,6 +1373,24 @@ afterEvaluate {
         if (mingwX64Test != null && isWindows && inCI) {
             mingwX64Test.doFirst { exec { commandLine("systeminfo") } }
             mingwX64Test.doLast { exec { commandLine("systeminfo") } }
+        }
+    }
+}
+
+afterEvaluate {
+    subprojects {
+        afterEvaluate {
+            if (project.path.startsWith(":samples:")) {
+                dependencies {
+                    add("commonMainApi", project(":korge"))
+                }
+
+                project.tasks.register("runJvmAwtSandbox", KorgeJavaExec::class.java) {
+                    group = "run"
+                    dependsOn("jvmMainClasses")
+                    mainClass.set("AwtSandboxSample")
+                }
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -845,7 +845,7 @@ samples {
     kotlin {
         jvm {
         }
-        js {
+        js(org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType.IR) {
             browser {
                 binaries.executable()
             }
@@ -1171,6 +1171,7 @@ enum class CrossExecType(val cname: String, val interp: String) {
     }
 }
 
+/*
 open class KotlinNativeCrossTest : org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest() {
     @Input
     @Option(option = "type", description = "Sets the executable cross type")
@@ -1200,6 +1201,7 @@ open class KotlinNativeCrossTest : org.jetbrains.kotlin.gradle.targets.native.ta
                 testArgs(testLogger, checkExitCode, testGradleFilter, testNegativeGradleFilter, userArgs)
     }
 }
+*/
 
 fun Exec.commandLineCross(vararg args: String, type: CrossExecType) {
     commandLine(*type.commands(*args))
@@ -1317,6 +1319,7 @@ subprojects {
                 for (type in CrossExecType.VALID_LIST) {
                     val linkDebugTest = project.tasks.findByName("linkDebugTest${type.nameWithArchCapital}") as? KotlinNativeLink?
                     if (linkDebugTest != null) {
+                        /*
                         tasks.create("${type.nameWithArch}Test${type.interpCapital}", KotlinNativeCrossTest::class.java, Action {
                             val link = linkDebugTest
                             val testResultsDir = project.buildDir.resolve(TestingBasePlugin.TEST_RESULTS_DIR_NAME)
@@ -1336,6 +1339,7 @@ subprojects {
                             group = "verification"
                             dependsOn(link)
                         })
+                        */
                     }
                 }
             }

--- a/buildSrc/src/main/kotlin/com/soywiz/korge/gradle/KorgeGradlePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korge/gradle/KorgeGradlePlugin.kt
@@ -49,7 +49,7 @@ class KorgeGradleApply(val project: Project) {
                     "java.version" to System.getProperty("java.version"),
                     "gradle.version" to GradleVersion.current(),
                     "groovy.version" to GroovySystem.getVersion(),
-                    "kotlin.version" to KotlinVersion.CURRENT,
+                    "kotlin.version" to "1.8.20-dev-36",
                 )) {
                     println(" - $key: $value")
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 jna = "5.11.0"
 jcodec = "0.2.5"
 proguard-gradle = "7.2.2"
-kotlin = "1.7.20-RC"
+kotlin = "1.8.20-dev-36"
 kotlinx-coroutines = "1.6.4"
 kotlinx-serialization = "1.4.0"
 kotlinx-atomicfu = "0.18.3"

--- a/korau/build.gradle
+++ b/korau/build.gradle
@@ -1,7 +1,7 @@
 description = "Portable Audio library for Kotlin"
 
-com.soywiz.korlibs.NativeTools.configureAllCInterop(project, "minimp3")
-com.soywiz.korlibs.NativeTools.configureAllCInterop(project, "stb_vorbis")
+//com.soywiz.korlibs.NativeTools.configureAllCInterop(project, "minimp3")
+//com.soywiz.korlibs.NativeTools.configureAllCInterop(project, "stb_vorbis")
 
 dependencies {
     add("commonMainApi", project(":korio"))

--- a/korgw/build.gradle
+++ b/korgw/build.gradle
@@ -1,6 +1,6 @@
 description = "Portable UI with accelerated graphics support for Kotlin"
 
-com.soywiz.korlibs.NativeTools.configureCInteropLinux(project, "X11Embed")
+//com.soywiz.korlibs.NativeTools.configureCInteropLinux(project, "X11Embed")
 
 dependencies {
     add("commonMainApi", project(":korim"))

--- a/korim/build.gradle
+++ b/korim/build.gradle
@@ -1,7 +1,7 @@
 description = "Korim: Kotlin cORoutines IMaging utilities for JVM, JS, Native and Common"
 
 //com.soywiz.korlibs.NativeTools.configureCInteropLinux(project, "stb_image")
-com.soywiz.korlibs.NativeTools.configureAllCInterop(project, "stb_image")
+//com.soywiz.korlibs.NativeTools.configureAllCInterop(project, "stb_image")
 
 dependencies {
 	add("commonMainApi", project(":korio"))

--- a/settings.gradle
+++ b/settings.gradle
@@ -51,3 +51,8 @@ if (!disabledExtraKorgeLibs) {
     include(":korge-box2d")
     include(":korge-fleks")
 }
+
+for (var n = 0; n < 50; n++) {
+    include(":samples:korge-fake-sample-$n")
+}
+


### PR DESCRIPTION
<img width="1441" alt="Screenshot 2022-09-21 at 14 09 05" src="https://user-images.githubusercontent.com/570848/191500058-ece08e0a-31f3-41ac-a344-77045c1c1efd.png">

The import finishes after 3 minutes, then it takes a lot longer to finish all the background tasks, and then there are a lot more repeated artifacts in the Libraries panel (one extra entry per project):

<img width="1441" alt="Screenshot 2022-09-21 at 14 16 10" src="https://user-images.githubusercontent.com/570848/191501314-0a5329a9-801e-4644-a467-65c57d18cb6b.png">
