### PR TITLE
Fixes ¿¡ symbols not displayed properly with the default font

### DIFF
--- a/korim/src/commonMain/kotlin/com/soywiz/korim/font/TtfFont.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/font/TtfFont.kt
@@ -1938,8 +1938,8 @@ abstract class BaseTtfFont(
             val gpath = ref.glyph.path.path
             GlyphGraphicsPath(ref.glyph.index, VectorPath(IntArrayList(gpath.commands.size), DoubleArrayList(gpath.data.size))).also { out ->
                 val m = Matrix()
-                m.translate(ref.x, -ref.y)
                 m.scale(ref.scaleX, ref.scaleY)
+                m.translate(ref.x, -ref.y)
                 out.path.write(ref.glyph.path.path, m)
             }
         }

--- a/korim/src/jvmTest/kotlin/com/soywiz/korim/font/ttf/TtfFontTest.kt
+++ b/korim/src/jvmTest/kotlin/com/soywiz/korim/font/ttf/TtfFontTest.kt
@@ -1,15 +1,11 @@
 package com.soywiz.korim.font.ttf
 
-import com.soywiz.korim.bitmap.*
-import com.soywiz.korim.color.*
 import com.soywiz.korim.font.*
-import com.soywiz.korim.format.*
+import com.soywiz.korim.vector.format.*
 import com.soywiz.korio.async.*
 import com.soywiz.korio.file.*
 import com.soywiz.korio.file.std.*
 import com.soywiz.korio.lang.*
-import com.soywiz.korio.stream.*
-import com.soywiz.korma.geom.*
 import kotlin.test.*
 
 class TtfFontTest {
@@ -39,6 +35,14 @@ class TtfFontTest {
         //println("smileyGlyph=${smileyGlyph?.codePoint},$smileyGlyph")
         //println(smileyGlyph?.colorEntry)
         //for (path in smileyGlyph!!.paths) println("path = $path")
+    }
+
+    @Test
+    fun testScaleOrder() = suspendTest {
+        assertEquals(
+            "M675 -800L475 -800L475 -1000L675 -1000L675 -800ZM200 0Q200 104, 288 177Q376 250, 500 250Q666 250, 783 177Q814 158, 836 136L940 240Q917 262, 889 283Q728 400, 500 400Q314 400, 182 283Q50 166, 50 0Q50 -230, 275 -340Q500 -450, 500 -600L650 -600Q650 -370, 425 -260Q200 -150, 200 0Z",
+            DefaultTtfFont.getGlyphPath(16.0, '¿'.code)!!.path.toSvgPathString()
+        )
     }
 
     //@Test


### PR DESCRIPTION
Fixes https://github.com/korlibs/korge/issues/954

![Screenshot 2022-10-19 at 11 19 19](https://user-images.githubusercontent.com/570848/196653005-156d7108-2488-4cbc-b546-369f25f3596c.png)
