### PR TITLE
Fix bug in BmpSlice.extractWithBase()

### DIFF
--- a/korge/src/commonTest/kotlin/com/soywiz/korge/atlas/AtlasInfoTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/atlas/AtlasInfoTest.kt
@@ -3,7 +3,7 @@ package com.soywiz.korge.atlas
 import com.soywiz.korim.atlas.Atlas
 import com.soywiz.korim.atlas.AtlasInfo
 import com.soywiz.korim.atlas.readAtlas
-import com.soywiz.korim.bitmap.BmpSlice
+import com.soywiz.korim.bitmap.*
 import com.soywiz.korio.async.suspendTest
 import com.soywiz.korio.file.std.resourcesVfs
 import com.soywiz.korio.lang.assert
@@ -59,6 +59,13 @@ class AtlasInfoTest {
         testSlice(atlas["4$ext"], true, true, false, 10, 10)  // yellow
         testSlice(atlas["5$ext"], true, false, true, 0, 10)  // magenta
         testSlice(atlas["6$ext"], false, true, true, 5, 5)  // cyan
+
+        testExtract(atlas["1$ext"], true, false, false, 0, 0) // red
+        testExtract(atlas["2$ext"], false, true, false, 0, 0) // green
+        testExtract(atlas["3$ext"], false, false, true, 10, 0) // blue
+        testExtract(atlas["4$ext"], true, true, false, 10, 10)  // yellow
+        testExtract(atlas["5$ext"], true, false, true, 0, 10)  // magenta
+        testExtract(atlas["6$ext"], false, true, true, 5, 5)  // cyan
     }
 
     fun testSlice(slice: BmpSlice, r: Boolean, g: Boolean, b: Boolean, xOffset: Int, yOffset: Int) {
@@ -84,6 +91,31 @@ class AtlasInfoTest {
             assert(col.r == if (r) c else 0, { "Slice ${slice.name} failed on pos $i at red" })
             assert(col.g == if (g) c else 0, { "Slice ${slice.name} failed on pos $i at green" })
             assert(col.b == if (b) c else 0, { "Slice ${slice.name} failed on pos $i at blue" })
+        }
+    }
+
+    fun testExtract(slice: BmpSlice, r: Boolean, g: Boolean, b: Boolean, xOffset: Int, yOffset: Int) {
+        val bmp = slice.extract()
+
+        if (slice.name == "1") {
+            assert(bmp.width == 32, { "Extracted slice ${slice.name} failed on width" })
+            assert(bmp.height == 46, { "Extracted slice ${slice.name} failed on height" })
+        } else {
+            assert(bmp.width == 42, { "Extracted slice ${slice.name} failed on width" })
+            assert(bmp.height == 56, { "Extracted slice ${slice.name} failed on height" })
+        }
+
+        for (i in 0 until 4) {
+            val col = when(i) {
+                1 -> bmp.getRgba(xOffset + 31, yOffset + 0)
+                2 -> bmp.getRgba(xOffset + 31, yOffset + 45)
+                3 -> bmp.getRgba(xOffset + 0, yOffset + 45)
+                else -> bmp.getRgba(xOffset + 0, yOffset + 0)
+            }
+            val c = 250 - i * 50
+            assert(col.r == if (r) c else 0, { "Extracted slice ${slice.name} failed on pos $i at red" })
+            assert(col.g == if (g) c else 0, { "Extracted slice ${slice.name} failed on pos $i at green" })
+            assert(col.b == if (b) c else 0, { "Extracted slice ${slice.name} failed on pos $i at blue" })
         }
     }
 }

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/atlas/AtlasInfoTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/atlas/AtlasInfoTest.kt
@@ -1,5 +1,6 @@
 package com.soywiz.korge.atlas
 
+import com.soywiz.kmem.*
 import com.soywiz.korim.atlas.Atlas
 import com.soywiz.korim.atlas.AtlasInfo
 import com.soywiz.korim.atlas.readAtlas
@@ -8,7 +9,6 @@ import com.soywiz.korio.async.suspendTest
 import com.soywiz.korio.file.std.resourcesVfs
 import com.soywiz.korio.lang.assert
 import com.soywiz.korio.lang.substr
-import com.soywiz.korio.util.OS
 import com.soywiz.korma.geom.Rectangle
 import com.soywiz.korma.geom.RectangleInt
 import com.soywiz.korma.geom.Size
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 
 class AtlasInfoTest {
     @Test
-    fun name() = suspendTest({ OS.isJvm }) {
+    fun name() = suspendTest({ Platform.isJvm }) {
         val atlas = AtlasInfo.loadJsonSpriter(resourcesVfs["demo.json"].readString())
         assertEquals("Spriter", atlas.app)
         assertEquals("r10", atlas.version)
@@ -37,17 +37,17 @@ class AtlasInfoTest {
     }
 
     @Test
-    fun atlasTestXml() = suspendTest({ OS.isJvm }) {
+    fun atlasTestXml() = suspendTest({ Platform.isJvm }) {
         testAtlas(resourcesVfs["atlas-test.xml"].readAtlas())
     }
 
     @Test
-    fun atlasTestJson() = suspendTest({ OS.isJvm }) {
+    fun atlasTestJson() = suspendTest({ Platform.isJvm }) {
         testAtlas(resourcesVfs["atlas-test.json"].readAtlas(), ".png")
     }
 
     @Test
-    fun atlasTestTxt() = suspendTest({ OS.isJvm }) {
+    fun atlasTestTxt() = suspendTest({ Platform.isJvm }) {
         testAtlas(resourcesVfs["atlas-test-spine.atlas.txt"].readAtlas())
     }
 
@@ -97,7 +97,7 @@ class AtlasInfoTest {
     fun testExtract(slice: BmpSlice, r: Boolean, g: Boolean, b: Boolean, xOffset: Int, yOffset: Int) {
         val bmp = slice.extract()
 
-        if (slice.name == "1") {
+        if (slice.name?.startsWith("1") == true) {
             assert(bmp.width == 32, { "Extracted slice ${slice.name} failed on width" })
             assert(bmp.height == 46, { "Extracted slice ${slice.name} failed on height" })
         } else {

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/BitmapSlice.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/BitmapSlice.kt
@@ -517,17 +517,29 @@ abstract class BmpSlice(
         val reverseX = width > 1 && if (rotated) tl_y > br_y else tl_x > br_x
         val reverseY = height > 1 && if (rotated) tl_x > br_x else tl_y > br_y
 
-        val out: T = if (frameOffsetX == 0 && frameOffsetY == 0 && frameWidth == width && frameHeight == height) {
+        val offsetX = if (reverseX) {
+            frameWidth - width - frameOffsetX
+        } else {
+            frameOffsetX
+        }
+
+        val offsetY = if (reverseY) {
+            frameHeight - height - frameOffsetY
+        } else {
+            frameOffsetY
+        }
+
+        val out: T = if (!rotated && offsetX == 0 && offsetY == 0 && frameWidth == width && frameHeight == height) {
             base.extract(x, y, width, height)
         } else {
             base.createWithThisFormatTyped(frameWidth, frameHeight).also { out ->
                 if (!rotated) {
-                    bmp.copyUnchecked(x, y, out, frameOffsetX, frameOffsetY, width, height)
+                    bmp.copyUnchecked(x, y, out, offsetX, offsetY, width, height)
                 } else {
                     val rgbaArray = IntArray(width)
                     for (x0 in 0 until height) {
                         bmp.readPixelsUnsafe(x + x0, y, 1, width, rgbaArray)
-                        out.writePixelsUnsafe(frameOffsetX, frameOffsetY + x0, width, 1, rgbaArray)
+                        out.writePixelsUnsafe(offsetX, offsetY + x0, width, 1, rgbaArray)
                     }
                 }
             }


### PR DESCRIPTION
`BmpSlice.extractWithBase()` returns Bitmaps with wrong content, if BmpSlice is rotated