### PR TITLE
Added CachedContainer functionality + improve _stage lookup by propagating it

### DIFF
--- a/kds/src/commonMain/kotlin/com/soywiz/kds/lock/Lock.kt
+++ b/kds/src/commonMain/kotlin/com/soywiz/kds/lock/Lock.kt
@@ -10,7 +10,8 @@ expect class Lock() {
 /**
  * Optimized lock that cannot be called inside another lock,
  * don't keep the current thread id, or a list of threads to awake
- * It is lightweight and just requires an atomic
+ * It is lightweight and just requires an atomic.
+ * Does busy-waiting instead of sleeping the thread.
  */
 expect class NonRecursiveLock() {
     inline operator fun <T> invoke(callback: () -> T): T

--- a/korge-sandbox/src/commonMain/kotlin/Main.kt
+++ b/korge-sandbox/src/commonMain/kotlin/Main.kt
@@ -26,6 +26,7 @@ suspend fun main() = Korge(
     debug = true,
     multithreaded = true,
     forceRenderEveryFrame = false // Newly added optimization!
+    //forceRenderEveryFrame = true
     //debugAg = true,
 ) {
     //uiButton("HELLO WORLD!", width = 300.0).position(100, 100); return@Korge
@@ -38,13 +39,15 @@ suspend fun main() = Korge(
         //Demo(::MainEditor),
         //Demo(::MainStage3d),
         //Demo(::MainInput),
-        Demo(::MainAnimations),
+        //Demo(::MainAnimations),
+        Demo(::MainCache),
         //Demo(::MainSvgAnimation),
         //Demo(::MainVectorNinePatch),
         listOf(
             Demo(::MainVectorNinePatch),
             Demo(::MainGraphicsText),
             Demo(::MainRpgScene),
+            Demo(::MainCache),
             Demo(::MainJSMpeg),
             Demo(::MainSDF),
             Demo(::MainTextInput),

--- a/korge-sandbox/src/commonMain/kotlin/samples/MainCache.kt
+++ b/korge-sandbox/src/commonMain/kotlin/samples/MainCache.kt
@@ -1,0 +1,39 @@
+package samples
+
+import com.soywiz.klock.*
+import com.soywiz.korge.scene.*
+import com.soywiz.korge.time.*
+import com.soywiz.korge.ui.*
+import com.soywiz.korge.view.*
+import com.soywiz.korim.color.*
+import com.soywiz.korma.random.*
+import kotlin.random.*
+
+//class MainCache : ScaledScene(512, 512) {
+class MainCache : Scene() {
+    override suspend fun SContainer.sceneMain() {
+        //val cached = CachedContainer().addTo(this)
+        //val cached = container {  }
+        val cached = cachedContainer {  }
+        val random = Random(0L)
+        for (n in 0 until 100_000) {
+            cached.solidRect(2, 2, random[Colors.RED, Colors.BLUE]).xy(2 * (n % 300), 2 * (n / 300))
+        }
+        uiHorizontalStack {
+            uiButton("Cached").clicked {
+                cached.cache = !cached.cache
+                it.text = if (cached.cache) "Cached" else "Uncached"
+            }
+            uiText("children=${cached.numChildren}")
+        }
+
+        interval(1.seconds) {
+            for (n in 0 until 2000) {
+                cached.getChildAt(50_000 + n).colorMul = random[Colors.RED, Colors.BLUE].mix(Colors.WHITE, 0.3)
+            }
+        }
+        //timeout(1.seconds) {
+        //    rect.color = Colors.BLUE
+        //}
+    }
+}

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/baseview/BaseView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/baseview/BaseView.kt
@@ -27,6 +27,10 @@ import com.soywiz.korio.lang.CloseableCancellable
 import kotlin.collections.set
 import kotlin.jvm.JvmName
 
+interface InvalidateNotifier {
+    fun invalidatedView(view: BaseView?)
+}
+
 //open class BaseView : BaseEventListener() {
 open class BaseView {
     protected open val baseParent: BaseView? get() = null

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/render/AgAutoFreeManager.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/render/AgAutoFreeManager.kt
@@ -1,0 +1,69 @@
+package com.soywiz.korge.render
+
+import com.soywiz.kds.*
+import com.soywiz.korag.*
+import com.soywiz.korio.lang.*
+
+// @TODO: This is pretty generic, we could expose it elsewhere
+class AgAutoFreeManager(
+) : Closeable {
+    class Entry(
+        var closeable: Closeable? = null,
+    ) {
+        fun closeAndReset() {
+            closeable?.close()
+            closeable = null
+        }
+        fun reset() {
+            closeable = null
+        }
+    }
+
+    private val entryPool = Pool(reset = { it.reset() }) { Entry() }
+    private val cachedCloseables = FastIdentityMap<Closeable?, Entry>()
+    private val availableInLastGC = fastArrayListOf<Entry>()
+
+    fun reference(closeable: Closeable) {
+        cachedCloseables.getOrPut(closeable) {
+            entryPool.alloc().also { it.closeable = closeable }
+        }
+    }
+
+    private var fcount = 0
+    var framesBetweenGC: Int = 60
+
+    internal fun afterRender() {
+        fcount++
+        if (fcount >= framesBetweenGC) {
+            fcount = 0
+            gc()
+        }
+    }
+
+    internal fun gc() {
+        // Delete elements that didn't survive the last GC
+        for (entry in availableInLastGC) {
+            if (!cachedCloseables.contains(entry.closeable)) {
+                entry.closeable?.close()
+                entryPool.free(entry)
+            }
+        }
+
+        // Reconstruct
+        availableInLastGC.clear()
+        cachedCloseables.fastValueForEach {
+            availableInLastGC.add(it)
+        }
+
+        // Clear cached entries
+        cachedCloseables.clear()
+    }
+
+    override fun close() {
+        availableInLastGC.fastForEach { it.closeAndReset() }
+        cachedCloseables.fastValueForEach { it.closeAndReset() }
+        availableInLastGC.clear()
+        entryPool.clear()
+        cachedCloseables.clear()
+    }
+}

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/render/BatchBuilder2D.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/render/BatchBuilder2D.kt
@@ -21,9 +21,7 @@ import com.soywiz.korag.shader.Varying
 import com.soywiz.korag.shader.VertexLayout
 import com.soywiz.korge.internal.KorgeInternal
 import com.soywiz.korge.view.BlendMode
-import com.soywiz.korim.bitmap.Bitmap
-import com.soywiz.korim.bitmap.Bitmaps
-import com.soywiz.korim.bitmap.BmpSlice
+import com.soywiz.korim.bitmap.*
 import com.soywiz.korim.color.ColorAdd
 import com.soywiz.korim.color.Colors
 import com.soywiz.korim.color.RGBA
@@ -259,7 +257,7 @@ class BatchBuilder2D constructor(
 		x1: Float, y1: Float,
 		x2: Float, y2: Float,
 		x3: Float, y3: Float,
-		tex: TextureCoords,
+		tex: BmpCoords,
 		colorMul: RGBA, colorAdd: ColorAdd,
         texIndex: Int = currentTexIndex,
         premultiplied: Boolean = tex.premultiplied,
@@ -687,20 +685,31 @@ class BatchBuilder2D constructor(
         wrap: Boolean = false,
         unit: Unit = Unit,
 	) {
+        setStateFast(tex.base, filtering, blendMode, program, icount = 6, vcount = 4)
+        drawQuadFast(x, y, width, height, m, tex, colorMul, colorAdd, premultiplied, wrap)
+	}
+
+    fun drawQuadFast(
+        x: Float, y: Float, width: Float, height: Float,
+        m: Matrix,
+        tex: BmpCoords,
+        colorMul: RGBA, colorAdd: ColorAdd,
+        premultiplied: Boolean = tex.premultiplied,
+        wrap: Boolean = false
+    ) {
         val x0 = x
         val x1 = (x + width)
         val y0 = y
         val y1 = (y + height)
-        setStateFast(tex.base, filtering, blendMode, program, icount = 6, vcount = 4)
         drawQuadFast(
             m.transformXf(x0, y0), m.transformYf(x0, y0),
             m.transformXf(x1, y0), m.transformYf(x1, y0),
             m.transformXf(x1, y1), m.transformYf(x1, y1),
             m.transformXf(x0, y1), m.transformYf(x0, y1),
-        	tex, colorMul, colorAdd,
+            tex, colorMul, colorAdd,
             premultiplied = premultiplied, wrap = wrap
         )
-	}
+    }
 
     enum class AddType(val index: Int) {
         NO_ADD(0),

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/render/RenderContext.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/render/RenderContext.kt
@@ -211,7 +211,6 @@ class RenderContext constructor(
     val rectPool = Pool(reset = { it.setTo(0, 0, 0, 0) }, preallocate = 8) { Rectangle() }
 
     val tempMargin: MutableMarginInt = MutableMarginInt()
-    val tempMatrix: Matrix = Matrix()
 
     val identityMatrix = Matrix()
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/render/RenderContext.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/render/RenderContext.kt
@@ -10,6 +10,7 @@ import com.soywiz.korge.view.*
 import com.soywiz.korim.bitmap.*
 import com.soywiz.korim.color.*
 import com.soywiz.korio.async.*
+import com.soywiz.korio.lang.*
 import com.soywiz.korma.geom.*
 import kotlin.coroutines.*
 
@@ -39,7 +40,7 @@ class RenderContext constructor(
 	val stats: Stats = Stats(),
 	val coroutineContext: CoroutineContext = EmptyCoroutineContext,
     val batchMaxQuads: Int = BatchBuilder2D.DEFAULT_BATCH_QUADS
-) : Extra by Extra.Mixin(), BoundsProvider by bp, AGFeatures by ag {
+) : Extra by Extra.Mixin(), BoundsProvider by bp, AGFeatures by ag, Closeable {
     val projectionMatrixTransform = Matrix()
     val projectionMatrixTransformInv = Matrix()
     private val projMat: Matrix3D = Matrix3D()
@@ -161,6 +162,7 @@ class RenderContext constructor(
         }
     }
 
+    val agAutoFreeManager = AgAutoFreeManager()
 	val agBitmapTextureManager = AgBitmapTextureManager(ag)
     val agBufferManager = AgBufferManager(ag)
 
@@ -326,9 +328,19 @@ class RenderContext constructor(
      */
     fun getTex(bmp: Bitmap): TextureBase = agBitmapTextureManager.getTextureBase(bmp)
 
+    /**
+     * References a [closeable] for this frame that will be tracked in next frames.
+     * If after a period of time, this closeable has not been referenced in between frames,
+     * the [Closeable.close] method will be called so the object can be freed.
+     *
+     * This can be use for example to automatically manage temporal/cached textures.
+     */
+    fun refGcCloseable(closeable: Closeable) = agAutoFreeManager.reference(closeable)
+
     internal fun afterRender() {
         flush()
         finish()
+        agAutoFreeManager.afterRender()
         agBitmapTextureManager.afterRender()
         agBufferManager.afterRender()
     }
@@ -339,6 +351,11 @@ class RenderContext constructor(
             currentBatcher = batcher
         }
         block(batcher)
+    }
+
+    override fun close() {
+        agBitmapTextureManager.close()
+        agAutoFreeManager.close()
     }
 }
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/CachedContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/CachedContainer.kt
@@ -1,10 +1,7 @@
 package com.soywiz.korge.view
 
-import com.soywiz.kmem.*
 import com.soywiz.korge.baseview.*
 import com.soywiz.korge.render.*
-import com.soywiz.korge.view.filter.*
-import com.soywiz.korim.bitmap.*
 import com.soywiz.korio.lang.*
 import com.soywiz.korma.geom.*
 
@@ -52,29 +49,22 @@ class CachedContainer(cache: Boolean = true) : Container(), InvalidateNotifier {
         val cache = _cacheTex!!
         ctx.refGcCloseable(cache)
 
-        // @TODO: Do this only when required so it is cached
-        //dirty = true
         if (dirty) {
             lbounds.copyFrom(getLocalBoundsOptimizedAnchored(includeFilters = false))
             dirty = false
             val texWidth = (lbounds.width).toInt().coerceAtLeast(1)
             val texHeight = (lbounds.height).toInt().coerceAtLeast(1)
-            //println("texWidth=$texWidth, texHeight=$texHeight")
             cache.resize(texWidth, texHeight)
             ctx.renderToFrameBuffer(cache.rb) {
-                @Suppress("DEPRECATION")
-                ctx.batch.setViewMatrixTemp(tempMat2d.also {
+                ctx.setViewMatrixTemp(tempMat2d.also {
                     it.copyFrom(globalMatrixInv)
                     it.translate(-lbounds.x, -lbounds.y)
                 }) {
-                    renderChildrenInternal(ctx)
+                    super.renderInternal(ctx)
                 }
             }
         }
 
-        //println("cache.tex=${cache.tex}")
-
-        ctx.flush()
         ctx.useBatcher { batch ->
             batch.drawQuad(
                 cache.tex,
@@ -87,7 +77,6 @@ class CachedContainer(cache: Boolean = true) : Container(), InvalidateNotifier {
                 blendMode = blendMode,
             )
         }
-        ctx.flush()
     }
 
     override fun setInvalidateNotifier() {

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/CachedContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/CachedContainer.kt
@@ -1,0 +1,105 @@
+package com.soywiz.korge.view
+
+import com.soywiz.kmem.*
+import com.soywiz.korge.baseview.*
+import com.soywiz.korge.render.*
+import com.soywiz.korge.view.filter.*
+import com.soywiz.korim.bitmap.*
+import com.soywiz.korio.lang.*
+import com.soywiz.korma.geom.*
+
+inline fun Container.cachedContainer(cache: Boolean = true, callback: @ViewDslMarker CachedContainer.() -> Unit = {}) =
+    CachedContainer(cache).addTo(this, callback)
+
+class CachedContainer(cache: Boolean = true) : Container(), InvalidateNotifier {
+    inner class CacheTexture(val ctx: RenderContext) : Closeable {
+        val rb = ctx.ag.unsafeAllocateFrameRenderBuffer(16, 16, onlyThisFrame = false)
+        val texBase = TextureBase(rb.tex, 16, 16)
+        var tex = Texture(texBase)
+
+        fun resize(width: Int, height: Int) {
+            rb.setSize(0, 0, width, height)
+            texBase.width = width
+            texBase.height = height
+            tex = Texture(texBase)
+        }
+        override fun close() {
+            _cacheTex = null
+            ctx.ag.unsafeFreeFrameRenderBuffer(rb)
+        }
+    }
+
+    var cache: Boolean = cache
+    private var _cacheTex: CacheTexture? = null
+    private val tempMat2d = Matrix()
+    private var dirty = true
+    private var lbounds = Rectangle()
+
+    override fun invalidateRender() {
+        dirty = true
+    }
+
+    override fun renderInternal(ctx: RenderContext) {
+        if (!visible) return
+        if (!cache) {
+            return super.renderInternal(ctx)
+        }
+
+        if (_cacheTex == null) {
+            _cacheTex = CacheTexture(ctx)
+            dirty = true
+        }
+        val cache = _cacheTex!!
+        ctx.refGcCloseable(cache)
+
+        // @TODO: Do this only when required so it is cached
+        //dirty = true
+        if (dirty) {
+            lbounds.copyFrom(getLocalBoundsOptimizedAnchored(includeFilters = false))
+            dirty = false
+            val texWidth = (lbounds.width).toInt().coerceAtLeast(1)
+            val texHeight = (lbounds.height).toInt().coerceAtLeast(1)
+            //println("texWidth=$texWidth, texHeight=$texHeight")
+            cache.resize(texWidth, texHeight)
+            ctx.renderToFrameBuffer(cache.rb) {
+                @Suppress("DEPRECATION")
+                ctx.batch.setViewMatrixTemp(tempMat2d.also {
+                    it.copyFrom(globalMatrixInv)
+                    it.translate(-lbounds.x, -lbounds.y)
+                }) {
+                    renderChildrenInternal(ctx)
+                }
+            }
+        }
+
+        //println("cache.tex=${cache.tex}")
+
+        ctx.flush()
+        ctx.useBatcher { batch ->
+            batch.drawQuad(
+                cache.tex,
+                m = tempMat2d.also {
+                    it.copyFrom(globalMatrix)
+                    it.pretranslate(lbounds.x, lbounds.y)
+                },
+                colorAdd = renderColorAdd,
+                colorMul = renderColorMul,
+                blendMode = blendMode,
+            )
+        }
+        ctx.flush()
+    }
+
+    override fun setInvalidateNotifier() {
+        _invalidateNotifier = this
+    }
+
+    init {
+        _invalidateNotifier = this
+    }
+
+    override fun invalidatedView(view: BaseView?) {
+        dirty = true
+        parent?._invalidateNotifier?.invalidatedView(view)
+    }
+}

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
@@ -4,6 +4,7 @@ import com.soywiz.kds.iterators.fastForEach
 import com.soywiz.korag.AG
 import com.soywiz.korag.annotation.KoragExperimental
 import com.soywiz.korev.EventDispatcher
+import com.soywiz.korge.baseview.*
 import com.soywiz.korge.debug.findObservableProperties
 import com.soywiz.korge.debug.uiCollapsibleSection
 import com.soywiz.korge.debug.uiEditableValue
@@ -31,6 +32,7 @@ class Stage(override val views: Views) : FixedSizeContainer()
     , ViewsContainer
     , ResourcesContainer
     , BoundsProvider by views.bp
+    , InvalidateNotifier
 {
     override var clip: Boolean by views::clipBorders
     override var width: Double by views::virtualWidthDouble
@@ -41,8 +43,13 @@ class Stage(override val views: Views) : FixedSizeContainer()
     val injector: AsyncInjector get() = views.injector
     val ag: AG get() = views.ag
     val gameWindow: GameWindow get() = views.gameWindow
-    override val stage: Stage = this
     override val resources get() = views.resources
+    override val stage: Stage get() = this
+
+    init {
+        this._stage = this
+        this._invalidateNotifier = this
+    }
 
     @KoragExperimental
     fun <T> runBlockingNoJs(block: suspend () -> T): T =
@@ -89,6 +96,10 @@ class Stage(override val views: Views) : FixedSizeContainer()
             }
         }
         super.buildDebugComponent(views, container)
+    }
+
+    override fun invalidatedView(view: BaseView?) {
+        views.invalidatedView(view)
     }
 
     override fun toString(): String = "Stage"

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Views.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Views.kt
@@ -28,7 +28,7 @@ import com.soywiz.korev.dispatch
 import com.soywiz.korge.Korge
 import com.soywiz.korge.KorgeReload
 import com.soywiz.korge.annotations.KorgeExperimental
-import com.soywiz.korge.baseview.BaseView
+import com.soywiz.korge.baseview.*
 import com.soywiz.korge.component.Component
 import com.soywiz.korge.component.EventComponent
 import com.soywiz.korge.component.GamepadComponent
@@ -120,7 +120,8 @@ class Views constructor(
 	BoundsProvider by bp,
     DialogInterfaceProvider by gameWindow,
     Closeable,
-    ResourcesContainer
+    ResourcesContainer,
+    InvalidateNotifier
 {
     override val views = this
 
@@ -553,7 +554,7 @@ class Views constructor(
         gameWindow.startFrame()
     }
 
-    fun invalidatedView(view: BaseView?) {
+    override fun invalidatedView(view: BaseView?) {
         //println("invalidatedView: $view")
         gameWindow.invalidatedView()
     }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/filter/ViewFilter.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/filter/ViewFilter.kt
@@ -7,9 +7,7 @@ import com.soywiz.kmem.toIntCeil
 import com.soywiz.korge.debug.uiCollapsibleSection
 import com.soywiz.korge.debug.uiEditableValue
 import com.soywiz.korge.render.RenderContext
-import com.soywiz.korge.view.View
-import com.soywiz.korge.view.ViewRenderPhase
-import com.soywiz.korge.view.addDebugExtraComponent
+import com.soywiz.korge.view.*
 import com.soywiz.korio.lang.portableSimpleName
 import kotlin.native.concurrent.ThreadLocal
 
@@ -73,7 +71,10 @@ var View.filterScale: Double by extraPropertyThis(transform = { Filter.discretiz
 //internal const val VIEW_FILTER_TRANSPARENT_EDGE = true
 internal const val VIEW_FILTER_TRANSPARENT_EDGE = false
 
-fun View.renderFiltered(ctx: RenderContext, filter: Filter, first: Boolean = true) {
+fun View.renderFiltered(
+    ctx: RenderContext, filter: Filter,
+    first: Boolean = true,
+) {
     val bounds = getLocalBoundsOptimizedAnchored(includeFilters = false)
 
     if (bounds.width <= 0.0 || bounds.height <= 0.0) return

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/render/AgAutoFreeManagerTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/render/AgAutoFreeManagerTest.kt
@@ -1,0 +1,23 @@
+package com.soywiz.korge.render
+
+import com.soywiz.korio.lang.*
+import kotlin.test.*
+
+class AgAutoFreeManagerTest {
+    @Test
+    fun test() {
+        var log = ""
+        val free = AgAutoFreeManager()
+        val a = CloseableCancellable { log += "a" }
+        val b = CloseableCancellable { log += "b" }
+        free.reference(a)
+        free.reference(b)
+        free.gc()
+        assertEquals("", log)
+        free.reference(a)
+        free.gc()
+        assertEquals("b", log)
+        free.gc()
+        assertEquals("ba", log)
+    }
+}

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/view/CachedContainerTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/view/CachedContainerTest.kt
@@ -1,0 +1,36 @@
+package com.soywiz.korge.view
+
+import com.soywiz.korge.render.*
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class CachedContainerTest {
+    @Test
+    fun testCachingWorks() {
+        val log = ViewsLog(EmptyCoroutineContext)
+        val root = Stage(log.views)
+        var rlog = ""
+        lateinit var view: DummyView
+        val cached = root.cachedContainer {
+            view = object : DummyView() {
+                override fun renderInternal(ctx: RenderContext) {
+                    rlog += "a"
+                }
+            }.addTo(this)
+        }
+        root.render(log.views.renderContext)
+        assertEquals("a", rlog, "First time, rendering of the descendants should happen")
+        root.render(log.views.renderContext)
+        assertEquals("a", rlog, "No re-rendering should happen")
+        view.x = 10.0
+        root.render(log.views.renderContext)
+        assertEquals("aa", rlog, "After updating a descendant, it should trigger a re-render")
+        root.render(log.views.renderContext)
+        assertEquals("aa", rlog, "But only once")
+        cached.cache = false
+        root.render(log.views.renderContext)
+        assertEquals("aaa", rlog, "After disabling the cache, re-rendering should happen always")
+        root.render(log.views.renderContext)
+        assertEquals("aaaa", rlog, "Always")
+    }
+}

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/AG.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/AG.kt
@@ -1331,11 +1331,11 @@ abstract class AG(val checked: Boolean = false) : AGFeatures, Extra by Extra.Mix
     }
 
     @KoragExperimental
-    fun unsafeAllocateFrameRenderBuffer(width: Int, height: Int, hasDepth: Boolean = false, hasStencil: Boolean = true, msamples: Int = 1): RenderBuffer {
+    fun unsafeAllocateFrameRenderBuffer(width: Int, height: Int, hasDepth: Boolean = false, hasStencil: Boolean = true, msamples: Int = 1, onlyThisFrame: Boolean = true): RenderBuffer {
         val realWidth = fixWidthForRenderToTexture(kotlin.math.max(width, 64))
         val realHeight = fixHeightForRenderToTexture(kotlin.math.max(height, 64))
         val rb = renderBuffers.alloc()
-        frameRenderBuffers += rb
+        if (onlyThisFrame) frameRenderBuffers += rb
         rb.setSize(0, 0, realWidth, realHeight, realWidth, realHeight)
         rb.setExtra(hasDepth = hasDepth, hasStencil = hasStencil)
         rb.setSamples(msamples)
@@ -1345,7 +1345,8 @@ abstract class AG(val checked: Boolean = false) : AGFeatures, Extra by Extra.Mix
 
     @KoragExperimental
     fun unsafeFreeFrameRenderBuffer(rb: RenderBuffer) {
-        frameRenderBuffers -= rb
+        if (frameRenderBuffers.remove(rb)) {
+        }
         renderBuffers.free(rb)
     }
 


### PR DESCRIPTION
This functionality supports caching a container to store the children in a texture and render that texture instead of all the children. It is integrated with the render invalidation system, so if a descendant changes calls invalidateRender, the texture is invalidated and the children re-rendered.
This support rendering huge hierarchies that don't change often, or small hierarchies with costly filters, super quickly.

This PR also improves how stage and render invalidator parent is computed, so it won't require iterating ancestors to get it which should be quicker for already constructed hierarchies.

The demo shows a node that has 100,000 solid rect children. When rendering those 100,000 children everyframe, it is pretty slow, but when cached into a texture, it is super fast (only rendering one texture). This demo also updates 2000 children every second, so when that happens, the children will be re-rendered into that texture once per second, while being lightning fast the rest of the frames.

For example, when doing UI, we could cache every UIWindow, so re-ndering is amortized.

https://user-images.githubusercontent.com/570848/201120451-4be95465-286d-49b5-bd31-8ffba22cee7f.mp4

Fixes https://github.com/korlibs/korge/issues/1064
Fixes https://github.com/korlibs/korge/issues/974