### PR TITLE
Add isActive check to animator

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/animate/Animator.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/animate/Animator.kt
@@ -170,6 +170,8 @@ open class Animator @PublishedApi internal constructor(
         return this
     }
 
+    val isActive: Boolean get() = updater != null && !rootAnimationNode.isEmpty()
+
     /**
      * Finishes all the pending animations and sets all the properties to their final state.
      */


### PR DESCRIPTION
Use case:
if there is already animation running, and it wasn't finished (isActive), don't do anything. Otherwise re-create animation.