### PR TITLE
Add UniformBlockData & UniformBlockBuffer

### DIFF
--- a/korgw/src/commonTest/kotlin/com/soywiz/korgw/AGUniformsTest.kt
+++ b/korgw/src/commonTest/kotlin/com/soywiz/korgw/AGUniformsTest.kt
@@ -1,0 +1,35 @@
+package com.soywiz.korgw
+
+import com.soywiz.kmem.*
+import com.soywiz.korag.shader.*
+import com.soywiz.korma.geom.*
+import kotlin.test.*
+
+class AGUniformsTest {
+    @Test
+    fun testUniformBlockDataAndBuffer() {
+        val projMatrix by Uniform(VarType.Mat4)
+        val viewMatrix by Uniform(VarType.Mat4)
+        val color1 by Uniform(VarType.UByte4)
+        val block = UniformBlock(projMatrix, viewMatrix, color1, layoutSize = null)
+        val data = UniformBlockData(block)
+        val buffer = UniformBlockBuffer(block, 2)
+        data[projMatrix].set(Matrix3D().multiply(2f))
+        val index1 = buffer.put(data)
+        data[projMatrix].set(Matrix3D().multiply(3f))
+        val index2 = buffer.put(data)
+        //println(buffer.buffer.f32.toFloatArray().toList())
+
+        assertEquals(listOf(0, 1), listOf(index1, index2))
+
+        buffer.copyIndexTo(index1, data)
+        assertEquals(Matrix3D().multiply(2f), Matrix3D().setColumns4x4(data[projMatrix].data.f32.toFloatArray(), 0))
+
+        buffer.copyIndexTo(index2, data)
+        assertEquals(Matrix3D().multiply(3f), Matrix3D().setColumns4x4(data[projMatrix].data.f32.toFloatArray(), 0))
+
+        //block.attributePositions
+        //println(block.totalSize)
+    }
+
+}

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Matrix3D.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Matrix3D.kt
@@ -119,21 +119,21 @@ class Matrix3D {
         return this
     }
 
-    fun setColumns4x4(f: FloatArray, offset: Int) = setColumns(
+    fun setColumns4x4(f: FloatArray, offset: Int): Matrix3D = setColumns(
         f[offset + 0], f[offset + 1], f[offset + 2], f[offset + 3],
         f[offset + 4], f[offset + 5], f[offset + 6], f[offset + 7],
         f[offset + 8], f[offset + 9], f[offset + 10], f[offset + 11],
         f[offset + 12], f[offset + 13], f[offset + 14], f[offset + 15]
     )
 
-    fun setRows4x4(f: FloatArray, offset: Int) = setRows(
+    fun setRows4x4(f: FloatArray, offset: Int): Matrix3D = setRows(
         f[offset + 0], f[offset + 1], f[offset + 2], f[offset + 3],
         f[offset + 4], f[offset + 5], f[offset + 6], f[offset + 7],
         f[offset + 8], f[offset + 9], f[offset + 10], f[offset + 11],
         f[offset + 12], f[offset + 13], f[offset + 14], f[offset + 15]
     )
 
-    fun setColumns3x3(f: FloatArray, offset: Int) = setColumns(
+    fun setColumns3x3(f: FloatArray, offset: Int): Matrix3D = setColumns(
         f[offset + 0], f[offset + 1], f[offset + 2], 0f,
         f[offset + 3], f[offset + 4], f[offset + 5], 0f,
         f[offset + 6], f[offset + 7], f[offset + 8], 0f,
@@ -419,8 +419,9 @@ class Matrix3D {
         rv30.toFloat(), rv31.toFloat(), rv32.toFloat(), rv33.toFloat(),
     )
 
-    fun multiply(scale: Float, l: Matrix3D = this) = this.apply {
+    fun multiply(scale: Float, l: Matrix3D = this): Matrix3D {
         for (n in 0 until 16) this.data[n] = l.data[n] * scale
+        return this
     }
 
     fun copyFrom(that: Matrix3D): Matrix3D {


### PR DESCRIPTION
Some work on https://github.com/korlibs/korge/issues/1116 & https://github.com/korlibs/korge/issues/465

For example for projection matrices, we should be able to push and pop indices in the UniformBlockBuffer, and only add new values to the buffer when the matrices change.
When doing a draw, we should reference the uniform buffers & indices in them. So we can upload the uniform buffers once, and reuse them later.