### PR TITLE
DirectGL on Win32. Hugely reduces OpenGL overhead on windows JVM: Use JNA 5.13 Library.OPTION_SYMBOL_PROVIDER to implement fast direct OpenGL mapping on Windows

### DIFF
--- a/buildSrc/src/main/kotlinGen/com/soywiz/korge/gradle/BuildVersions.kt
+++ b/buildSrc/src/main/kotlinGen/com/soywiz/korge/gradle/BuildVersions.kt
@@ -2,9 +2,9 @@ package com.soywiz.korge.gradle
 
 object BuildVersions {
     const val GIT = "main"
-    const val KOTLIN = "1.8.0"
+    const val KOTLIN = "1.7.21"
     const val NODE_JS = "16.9.1"
-    const val JNA = "5.12.1"
+    const val JNA = "5.13.0"
     const val COROUTINES = "1.6.4"
     const val ANDROID_BUILD = "7.0.4"
     const val KOTLIN_SERIALIZATION = "1.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jna = "5.12.1"
+jna = "5.13.0"
 jcodec = "0.2.5"
 proguard-gradle = "7.2.2"
 kotlin = "1.7.21"

--- a/korgw/src/jvmMain/kotlin/com/soywiz/korgw/platform/NativeKgl.kt
+++ b/korgw/src/jvmMain/kotlin/com/soywiz/korgw/platform/NativeKgl.kt
@@ -6,7 +6,7 @@ import com.soywiz.korim.awt.AwtNativeImage
 import com.soywiz.korim.bitmap.NativeImage
 import com.sun.jna.NativeLong
 
-open class NativeKgl(private val gl: INativeGL) : KmlGlWithExtensions() {
+open class NativeKgl constructor(private val gl: INativeGL) : KmlGlWithExtensions() {
     override fun activeTexture(texture: Int): Unit = gl.glActiveTexture(texture)
     override fun attachShader(program: Int, shader: Int): Unit = gl.glAttachShader(program, shader)
     override fun bindAttribLocation(program: Int, index: Int, name: String): Unit = gl.glBindAttribLocation(program, index, name)

--- a/korgw/src/jvmMain/kotlin/com/soywiz/korgw/win32/Win32Tools.kt
+++ b/korgw/src/jvmMain/kotlin/com/soywiz/korgw/win32/Win32Tools.kt
@@ -8,6 +8,7 @@ import com.soywiz.korgw.GameWindowConfig
 import com.soywiz.korgw.platform.BaseOpenglContext
 import com.soywiz.korgw.platform.INativeGL
 import com.soywiz.korgw.platform.NativeKgl
+import com.soywiz.korgw.platform.DirectGL
 import com.soywiz.korim.bitmap.Bitmap32
 import com.soywiz.korio.lang.Environment
 import com.sun.jna.*
@@ -35,11 +36,11 @@ open class Win32KmlGl : NativeKgl(Win32GL) {
             vertexArrayCachedVersion = contextVersion
             val out = intArrayOf(-1)
             //checkError("before glGenVertexArrays")
-            Win32GL.glGenVertexArrays(1, out)
+            DirectGL.glGenVertexArrays(1, out)
             checkError("glGenVertexArrays")
             vertexArray = out[0]
         }
-        Win32GL.glBindVertexArray(vertexArray)
+        DirectGL.glBindVertexArray(vertexArray)
         //checkError("glBindVertexArray")
     }
 }
@@ -53,9 +54,6 @@ interface Win32GL : INativeGL, Library {
     fun wglChoosePixelFormatARB(hDC: HDC, piAttribIList: IntArray?, pfAttribFList: FloatArray?, nMaxFormats: Int, piFormats: Pointer?, nNumFormats: Pointer?): Int
     //fun wglCreateContextAttribsARB(hDC: HDC, hshareContext: WinGDI.PIXELFORMATDESCRIPTOR.ByReference?, attribList: Pointer?): Int
     fun wglCreateContextAttribsARB(hDC: HDC, hshareContext: WinGDI.PIXELFORMATDESCRIPTOR.ByReference?, attribList: IntArray?): HGLRC?
-
-    fun glGenVertexArrays(n: Int, out: IntArray)
-    fun glBindVertexArray(varray: Int)
 
     companion object : Win32GLBase(Win32GLLoader())
 


### PR DESCRIPTION
Since JNA 5.13 we have this: https://github.com/java-native-access/jna/pull/1490

Superseeds https://github.com/korlibs/korge/pull/1140 without the need of custom JNA binaries

See https://github.com/java-native-access/jna/blob/master/www/DirectMapping.md