### PR TITLE
Bump to Kotlin 1.8.10, unify K/N configuration and disable custom freeCompilerArgs

### DIFF
--- a/buildSrc/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
@@ -259,7 +259,6 @@ class KorgeExtension(val project: Project) {
     val DEFAULT_JVM_TARGET = "1.8"
     //val DEFAULT_JVM_TARGET = "1.6"
 	var jvmTarget: String = project.findProject("jvm.target")?.toString() ?: DEFAULT_JVM_TARGET
-    var useMimalloc = true
 	var androidLibrary: Boolean = project.findProperty("android.library") == "true"
     var overwriteAndroidFiles: Boolean = project.findProperty("overwrite.android.files") == "false"
     var id: String = "com.unknown.unknownapp"

--- a/buildSrc/src/main/kotlin/com/soywiz/korge/gradle/targets/native/NativeExt.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korge/gradle/targets/native/NativeExt.kt
@@ -1,8 +1,5 @@
 package com.soywiz.korge.gradle.targets.native
 
-import com.android.build.gradle.internal.crash.afterEvaluate
-import com.soywiz.korge.gradle.*
-import com.soywiz.korlibs.*
 import org.gradle.api.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
@@ -24,32 +21,5 @@ fun KotlinNativeCompilation.getCompileTask(kind: NativeOutputKind, type: NativeB
 val KotlinNativeTest.executableFolder get() = executable.parentFile ?: error("Can't get executable folder for KotlinNativeTest")
 
 fun KotlinTarget.configureKotlinNativeTarget(project: Project) {
-    // mimalloc is broken on raspberry pi
-    if (project.korge.useMimalloc && !targetName.contains("Arm32Hfp")) {
-        compilations.all {
-            it.kotlinOptions.freeCompilerArgs += listOf(
-                "-Xallocator=mimalloc",
-                // https://kotlinlang.slack.com/archives/C3SGXARS6/p1620909233323100?thread_ts=1619349974.244300&cid=C3SGXARS6
-                // https://github.com/JetBrains/kotlin/blob/ec6c25ef7ee3e9d89bf9a03c01e4dd91789000f5/kotlin-native/konan/konan.properties#L875
-                //"-Xoverride-konan-properties=clangFlags.mingw_x64=-cc1 -emit-obj -disable-llvm-passes -x ir -femulated-tls -target-cpu x86-64"
-                "-Xoverride-konan-properties=clangFlags.mingw_x64=-cc1 -emit-obj -disable-llvm-passes -x ir -target-cpu x86-64"
-            )
-        }
-    }
-
-    // https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#switch-to-the-new-mm
-    project.extra["kotlin.native.binary.memoryModel"] = "experimental"
-    //project.setProperty("kotlin.native.binary.memoryModel", "experimental") // Could not set unknown property 'kotlin.native.binary.memoryModel' for root project 'e2e-sample' of type org.gradle.api.Project.
-    (this as? KotlinNativeTarget?)?.apply {
-        compilations.all {
-            it.kotlinOptions.freeCompilerArgs += listOf(
-                "-Xbinary=memoryModel=experimental",
-                // @TODO: https://youtrack.jetbrains.com/issue/KT-49234#focus=Comments-27-5293935.0-0
-                //"-Xdisable-phases=RemoveRedundantCallsToFileInitializersPhase",
-            )
-        }
-        binaries.allThis {
-            binaryOptions["memoryModel"] = "experimental"
-        }
-    }
+    // Do nothing for now
 }

--- a/buildSrc/src/main/kotlin/com/soywiz/korlibs/root/RootKorlibsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korlibs/root/RootKorlibsPlugin.kt
@@ -758,20 +758,7 @@ object RootKorlibsPlugin {
                     }.toList()
 
                     for (target in desktopAndMobileTargets) {
-                        target.compilations.allThis {
-                            // https://github.com/JetBrains/kotlin/blob/ec6c25ef7ee3e9d89bf9a03c01e4dd91789000f5/kotlin-native/konan/konan.properties#L875
-                            kotlinOptions.freeCompilerArgs = ArrayList<String>().apply {
-                                // Raspberry Pi doesn't support mimalloc at this time
-                                if (useMimalloc && !target.name.contains("Arm32Hfp")) add("-Xallocator=mimalloc")
-                                add("-Xoverride-konan-properties=clangFlags.mingw_x64=-cc1 -emit-obj -disable-llvm-passes -x ir -target-cpu x86-64")
-                            }
-                            kotlinOptions.freeCompilerArgs += listOf(
-                                "-Xbinary=memoryModel=experimental",
-                                // @TODO: https://youtrack.jetbrains.com/issue/KT-49234#focus=Comments-27-5293935.0-0
-                                //"-Xdisable-phases=RemoveRedundantCallsToFileInitializersPhase",
-                            )
-                            kotlinOptions.suppressWarnings = true
-                        }
+                        target.configureKotlinNativeTarget(project)
                     }
 
                     // common
@@ -1551,7 +1538,6 @@ object RootKorlibsPlugin {
 //val headlessTests = true
 //val headlessTests = System.getenv("NON_HEADLESS_TESTS") != "true"
 val headlessTests: Boolean get() = System.getenv("CI") == "true" || System.getenv("HEADLESS_TESTS") == "true"
-val useMimalloc: Boolean get() = true
 //val useMimalloc = false
 
 val Project._libs: Dyn get() = rootProject.extensions.getByName("libs").dyn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 jna = "5.13.0"
 jcodec = "0.2.5"
 proguard-gradle = "7.2.2"
-kotlin = "1.8.0"
+kotlin = "1.8.10"
 kotlinx-coroutines = "1.6.4"
 kotlinx-serialization = "1.5.0-RC"
 kotlinx-atomicfu = "0.19.0"


### PR DESCRIPTION
Rationale of removing flags here: https://youtrack.jetbrains.com/issue/KT-56395/Kotlin-1.8.10-stdoncecallable-error-on-K-N-windows#focus=Comments-27-6835406.0-0

Kotlin 1.8.10 changelog: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10