### PR TITLE
Remove external sampler functionality

### DIFF
--- a/korge/src/jvmTest/kotlin/com/soywiz/korge/render/BatchBuilderShaderTest.kt
+++ b/korge/src/jvmTest/kotlin/com/soywiz/korge/render/BatchBuilderShaderTest.kt
@@ -13,10 +13,10 @@ class BatchBuilderShaderTest {
         assertEqualsFileReference("korge/render/Default.frag.log", fragmentText)
     }
 
-    @Test
-    fun testExternalTextureSampler() {
-        val program = BatchBuilder2D.getTextureLookupProgram(BatchBuilder2D.AddType.POST_ADD)
-        val fragmentText = program.fragment.toNewGlslString(GlslConfig(programConfig = ProgramConfig.EXTERNAL_TEXTURE_SAMPLER))
-        assertEqualsFileReference("korge/render/ExternalTextureSampler.frag.log", fragmentText)
-    }
+    //@Test
+    //fun testExternalTextureSampler() {
+    //    val program = BatchBuilder2D.getTextureLookupProgram(BatchBuilder2D.AddType.POST_ADD)
+    //    val fragmentText = program.fragment.toNewGlslString(GlslConfig(programConfig = ProgramConfig.EXTERNAL_TEXTURE_SAMPLER))
+    //    assertEqualsFileReference("korge/render/ExternalTextureSampler.frag.log", fragmentText)
+    //}
 }

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/gl/AGOpengl.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/gl/AGOpengl.kt
@@ -86,10 +86,11 @@ class AGOpengl(val gl: KmlGl) : AG() {
     //private val normalPrograms = FastIdentityMap<Program, AgProgram>()
     //private val externalPrograms = FastIdentityMap<Program, AgProgram>()
     private val normalPrograms = HashMap<Program, GLBaseProgram>()
-    private val externalPrograms = HashMap<Program, GLBaseProgram>()
+    //private val externalPrograms = HashMap<Program, GLBaseProgram>()
 
     private fun useProgram(program: Program, config: ProgramConfig = ProgramConfig.DEFAULT) {
-        val map = if (config.externalTextureSampler) externalPrograms else normalPrograms
+        //val map = if (config.externalTextureSampler) externalPrograms else normalPrograms
+        val map = normalPrograms
         val nprogram: GLBaseProgram = map.getOrPut(program) {
             GLBaseProgram(glGlobalState, GLShaderCompiler.programCreate(
                 gl,
@@ -147,7 +148,7 @@ class AGOpengl(val gl: KmlGl) : AG() {
         }
 
         useProgram(program, config = when {
-            uniforms.useExternalSampler() -> ProgramConfig.EXTERNAL_TEXTURE_SAMPLER
+            //uniforms.useExternalSampler() -> ProgramConfig.EXTERNAL_TEXTURE_SAMPLER
             else -> ProgramConfig.DEFAULT
         })
         uniformsSet(uniforms)
@@ -857,24 +858,24 @@ class AGOpengl(val gl: KmlGl) : AG() {
         glGlobalState.readStats(out)
     }
 
-    fun AGUniformValues.useExternalSampler(): Boolean {
-        var useExternalSampler = false
-        this.fastForEach { value ->
-            val uniform = value.uniform
-            val uniformType = uniform.type
-            when (uniformType) {
-                VarType.Sampler2D -> {
-                    val tex = value.texture
-                    if (tex != null) {
-                        if (tex.implForcedTexTarget == AGTextureTargetKind.EXTERNAL_TEXTURE) {
-                            useExternalSampler = true
-                        }
-                    }
-                }
-                else -> Unit
-            }
-        }
-        //println("useExternalSampler=$useExternalSampler")
-        return useExternalSampler
-    }
+    //fun AGUniformValues.useExternalSampler(): Boolean {
+    //    var useExternalSampler = false
+    //    this.fastForEach { value ->
+    //        val uniform = value.uniform
+    //        val uniformType = uniform.type
+    //        when (uniformType) {
+    //            VarType.Sampler2D -> {
+    //                val tex = value.texture
+    //                if (tex != null) {
+    //                    if (tex.implForcedTexTarget == AGTextureTargetKind.EXTERNAL_TEXTURE) {
+    //                        useExternalSampler = true
+    //                    }
+    //                }
+    //            }
+    //            else -> Unit
+    //        }
+    //    }
+    //    //println("useExternalSampler=$useExternalSampler")
+    //    return useExternalSampler
+    //}
 }

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslGenerator.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslGenerator.kt
@@ -134,9 +134,9 @@ class GlslGenerator constructor(
                         line("#version $version")
                     }
                 }
-                if (config.programConfig.externalTextureSampler) {
-                    line("#extension GL_OES_EGL_image_external : require")
-                }
+                //if (config.programConfig.externalTextureSampler) {
+                //    line("#extension GL_OES_EGL_image_external : require")
+                //}
                 line("#ifdef GL_ES")
                 indent {
                     line("precision highp float;")
@@ -337,7 +337,8 @@ interface BaseGlslGenerator {
         VarType.Mat3 -> "mat3"
         VarType.Mat4 -> "mat4"
         VarType.Sampler1D -> "sampler1D"
-        VarType.Sampler2D -> if (config.programConfig.externalTextureSampler) "samplerExternalOES" else "sampler2D"
+        VarType.Sampler2D -> "sampler2D"
+        //VarType.Sampler2D -> if (config.programConfig.externalTextureSampler) "samplerExternalOES" else "sampler2D"
         VarType.Sampler3D -> "sampler3D"
         VarType.SamplerCube -> "samplerCube"
         else -> {

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/shaders.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/shaders.kt
@@ -307,11 +307,12 @@ object Output : Varying("out", VarType.Float4) {
 }
 
 data class ProgramConfig(
-    val externalTextureSampler: Boolean = false
+    val dummy: Boolean = false,
+    //val externalTextureSampler: Boolean = false
 ) {
     companion object {
         val DEFAULT = ProgramConfig()
-        val EXTERNAL_TEXTURE_SAMPLER = ProgramConfig(externalTextureSampler = true)
+        //val EXTERNAL_TEXTURE_SAMPLER = ProgramConfig(externalTextureSampler = true)
     }
 }
 


### PR DESCRIPTION
If some consumers require it, they can convert the texture with another shader. This should simplify code along avoid specific driver bugs with complex shaders with external samplers