### PR TITLE
Try to debug linux egl/mesa with envs

### DIFF
--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -88,7 +88,7 @@ jobs:
     - { name: Grant execute permission for gradlew, run: chmod +x gradlew }
     - { name: Start gradle, run: ./gradlew }
     - { name: Building classes, run: ./gradlew compileTestKotlinJvm }
-    - { name: Testing JVM, run: "./gradlew jvmTest" }
+    - { name: Testing JVM, run: "./gradlew jvmTest", env: { EGL_LOG_LEVEL: debug, LIBGL_DEBUG: verbose, LIBGL_ALWAYS_SOFTWARE: true, MESA_DEBUG: true } }
     - { name: Check sandbox compiles, run: "./gradlew :korge-sandbox:jvmJar" }
     - { name: Publish to maven local, run: ./gradlew publishJvmLocal }
     - { name: e2e test, working-directory: e2e-test, run: ./gradlew checkReferencesJvm --stacktrace }


### PR DESCRIPTION
Tried docker with ubuntu server, vmware with ubuntu server images, wsl2.

The same with a window machine: tried docker with nanoserver/server and vmware with windows server 2022 minimum to try to reproduce a very small environment and was not able to reproduce context errors on windows/linux/mac.

In the case of linux I was not able to reproduce this error, except when DISPLAY/xvfb was not set. So let's try to use environment variables to figure out what's going on?

* https://docs.mesa3d.org/egl.html#environment-variables
* https://docs.mesa3d.org/envvars.html#libgl-environment-variables