### PR TITLE
Do not require ANDROID_TESTS=true for android connected checks

### DIFF
--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -13,7 +13,6 @@ concurrency:
 env:
   CI: true
   SKIP_KORGE_SAMPLES: true
-  ANDROID_TESTS: true
   DISPLAY: ":99"
 
 jobs:

--- a/buildSrc/src/main/kotlin/com/soywiz/korlibs/root/RootKorlibsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korlibs/root/RootKorlibsPlugin.kt
@@ -596,19 +596,12 @@ object RootKorlibsPlugin {
                     android.apply {
                         sourceSets {
                             it.maybeCreate("main").apply {
-                                if (System.getenv("ANDROID_TESTS") == "true") {
-                                    assets.srcDirs(
-                                        "src/commonMain/resources",
-                                        "src/commonTest/resources",
-                                    )
-                                } else {
-                                    assets.srcDirs("src/commonMain/resources",)
-                                }
+                                assets.srcDirs("src/commonMain/resources",)
                             }
-                            it.maybeCreate("test").apply {
-                                assets.srcDirs(
-                                    "src/commonTest/resources",
-                                )
+                            for (name in listOf("test", "testDebug", "testRelease", "androidTest", "androidTestDebug", "androidTestRelease")) {
+                                it.maybeCreate(name).apply {
+                                    assets.srcDirs("src/commonTest/resources",)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
It seemed that the "test" sourceSet was not including the assets in the generated test apk