### PR TITLE
Fixes KorTE's JVM ObjectMapper to not redirect to the field if the getter returned null

### DIFF
--- a/korte/src/jvmAndroidMain/kotlin/com/soywiz/korte/dynamic/ObjectMapper2Native.kt
+++ b/korte/src/jvmAndroidMain/kotlin/com/soywiz/korte/dynamic/ObjectMapper2Native.kt
@@ -57,17 +57,21 @@ open class JvmObjectMapper2 : ObjectMapper2() {
     override suspend fun set(instance: Any, key: Any?, value: Any?) {
         if (instance is DynamicType<*>) return instance.dynamicShape.setProp(instance, key, value)
         val prop = instance::class.classInfo.propByName[key] ?: return
-        if (prop.setter != null) {
-            prop.setter?.invoke(instance, value)
-        } else {
-            prop.field?.set(instance, value)
+        when {
+            prop.setter != null -> prop.setter.invoke(instance, value)
+            prop.field != null -> prop.field.set(instance, value)
+            else -> Unit
         }
     }
 
     override suspend fun get(instance: Any, key: Any?): Any? {
         if (instance is DynamicType<*>) return instance.dynamicShape.getProp(instance, key)
         val prop = instance::class.classInfo.propByName[key] ?: return null
-        return prop.getter?.invoke(instance) ?: prop.field?.get(instance)
+        return when {
+            prop.getter != null -> prop.getter.invoke(instance)
+            prop.field != null -> prop.field.get(instance)
+            else -> null
+        }
     }
 }
 

--- a/korte/src/jvmTest/kotlin/com/soywiz/korte/TemplateJvmTest.kt
+++ b/korte/src/jvmTest/kotlin/com/soywiz/korte/TemplateJvmTest.kt
@@ -39,4 +39,21 @@ class TemplateJvmTest {
             Template("{% for row in rows %}{% if row.date >= startDate && row.date < startDate.plusDays(days) %}{{ row.title }},{% endif %}{% endfor %}")("startDate" to startDate, "days" to days, "rows" to rows)
         )
     }
+
+    @Suppress("unused")
+    class Getter {
+        @JvmField var a: Int? = 10
+        @JvmField var b: Int? = 10
+        var c: Int? = 10
+        fun getA(): Int? = null
+        fun getB(): Int? = 20
+    }
+
+    @Test
+    fun testGetter() = suspendTest {
+        assertEquals(
+            ",20,10",
+            Template("{{ data.a }},{{ data.b }},{{ data.c }}")("data" to Getter())
+        )
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/korlibs/korge/issues/1406