### PR TITLE
runJs: correct MIME type for wasm files

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
@@ -174,6 +174,7 @@ fun File.miniMimeType() = when (this.extension.toLowerCase()) {
     "jpg", "jpeg" -> "image/jpeg"
     "svg" -> "image/svg+xml"
     "mp3" -> "audio/mpeg"
+    "wasm" -> "application/wasm"
     else -> if (this.exists()) Files.probeContentType(this.toPath()) ?: "application/octet-stream" else "text/plain"
 }
 


### PR DESCRIPTION
Currently wasm files are served with `application/octet-stream` by the builtin `staticHttpServer` task used in `runJs` which causes browser error, i.e. with `WebAssembly.instantiateStreaming`.
I understand that wasm is not supported by Korge yet, but it can still be used in source-sets independent from Korge, i.e. to offload heavy game computations.