### PR TITLE
runJs: correct MIME type for JavaScript modules

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
@@ -175,7 +175,7 @@ fun File.miniMimeType() = when (this.extension.toLowerCase()) {
     "svg" -> "image/svg+xml"
     "mp3" -> "audio/mpeg"
     "wasm" -> "application/wasm"
-    "mjs" -> "text/javascript"
+    "js", "mjs" -> "text/javascript"
     else -> if (this.exists()) Files.probeContentType(this.toPath()) ?: "application/octet-stream" else "text/plain"
 }
 

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
@@ -175,6 +175,7 @@ fun File.miniMimeType() = when (this.extension.toLowerCase()) {
     "svg" -> "image/svg+xml"
     "mp3" -> "audio/mpeg"
     "wasm" -> "application/wasm"
+    "mjs" -> "text/javascript"
     else -> if (this.exists()) Files.probeContentType(this.toPath()) ?: "application/octet-stream" else "text/plain"
 }
 


### PR DESCRIPTION
Similar to this [one](https://github.com/korlibs/korge/pull/1562), but now for the [commonly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) used JavaScript `*.mjs` module files.