### PR TITLE
Fixes localTimezoneOffsetMinutes in apple platforms & adds DateTime.cfAbsoluteTime & DateTime.Companion.fromCFAbsoluteTime

### DIFF
--- a/klock/src/darwinMain/kotlin/korlibs/time/darwin/DateExt.kt
+++ b/klock/src/darwinMain/kotlin/korlibs/time/darwin/DateExt.kt
@@ -1,0 +1,8 @@
+package korlibs.time.darwin
+
+import korlibs.time.*
+
+fun DateTime.cfAbsoluteTime(): Double = (this - DateTime(2001, Month.January, 1, 0, 0, 0, 0)).seconds
+
+fun DateTime.Companion.fromCFAbsoluteTime(cfAbsoluteTime: Double): DateTime =
+    DateTime(2001, Month.January, 1, 0, 0, 0, 0) + cfAbsoluteTime.seconds

--- a/klock/src/darwinMain/kotlin/korlibs/time/internal/KlockInternal.kt
+++ b/klock/src/darwinMain/kotlin/korlibs/time/internal/KlockInternal.kt
@@ -1,6 +1,7 @@
 package korlibs.time.internal
 
 import korlibs.time.*
+import korlibs.time.darwin.*
 import korlibs.time.hr.*
 import kotlinx.cinterop.*
 import platform.CoreFoundation.*
@@ -32,11 +33,12 @@ internal actual object KlockInternal {
     }
 
     actual fun localTimezoneOffsetMinutes(time: DateTime): TimeSpan = autoreleasepool {
+        CFAbsoluteTimeGetCurrent()
         return getLocalTimezoneOffsetDarwin(CFTimeZoneCopySystem(), time)
     }
 }
 
 internal fun getLocalTimezoneOffsetDarwin(tz: CFTimeZoneRef?, time: DateTime): TimeSpan {
-    val secondsSince2001 = (time - DateTime(2001, Month.January, 1, 0, 0, 0, 0)).seconds
+    val secondsSince2001 = time.cfAbsoluteTime()
     return (CFTimeZoneGetSecondsFromGMT(tz, secondsSince2001.toDouble()) / 60.0).minutes
 }

--- a/klock/src/darwinMain/kotlin/korlibs/time/internal/KlockInternal.kt
+++ b/klock/src/darwinMain/kotlin/korlibs/time/internal/KlockInternal.kt
@@ -32,8 +32,11 @@ internal actual object KlockInternal {
     }
 
     actual fun localTimezoneOffsetMinutes(time: DateTime): TimeSpan = autoreleasepool {
-        val tz: CFTimeZoneRef? = CFTimeZoneCopySystem()
-        val minsFromGMT: CFTimeInterval = CFTimeZoneGetSecondsFromGMT(tz, CFAbsoluteTimeGetCurrent()) / 60.0
-        minsFromGMT.minutes
+        return getLocalTimezoneOffsetDarwin(CFTimeZoneCopySystem(), time)
     }
+}
+
+internal fun getLocalTimezoneOffsetDarwin(tz: CFTimeZoneRef?, time: DateTime): TimeSpan {
+    val secondsSince2001 = (time - DateTime(2001, Month.January, 1, 0, 0, 0, 0)).seconds
+    return (CFTimeZoneGetSecondsFromGMT(tz, secondsSince2001.toDouble()) / 60.0).minutes
 }

--- a/klock/src/darwinTest/kotlin/korlibs/time/internal/KlockInternalDarwinTest.kt
+++ b/klock/src/darwinTest/kotlin/korlibs/time/internal/KlockInternalDarwinTest.kt
@@ -1,0 +1,39 @@
+package korlibs.time.internal
+
+import korlibs.time.*
+import kotlinx.cinterop.*
+import platform.CoreFoundation.*
+import kotlin.test.*
+
+class KlockInternalDarwinTest {
+    @Test
+    fun test() {
+        val names = CFTimeZoneCopyKnownNames().toStrArray().filterNotNull().toList()
+        assertEquals(true, "Europe/Madrid" in names)
+        val EuropeMadrid = CFTimeZoneCreateWithName(null, CFStringCreateWithCString(null, "Europe/Madrid", kCFStringEncodingUTF8), true)
+        //val CET = CFTimeZoneCreateWithName(null, CFStringCreateWithCString(null, "CET", kCFStringEncodingUTF8), true)
+        //val CEST = CFTimeZoneCreateWithName(null, CFStringCreateWithCString(null, "CEST", kCFStringEncodingUTF8), true)
+
+        // CEST (UTC +2)
+        // CET (UTC +1)
+        assertEquals(
+            """
+                CEST: 120
+                CET: 60
+            """.trimIndent(),
+            """
+                CEST: ${getLocalTimezoneOffsetDarwin(EuropeMadrid, DateTime(2023, Month.July, 10)).minutes.toInt()}
+                CET: ${getLocalTimezoneOffsetDarwin(EuropeMadrid, DateTime(2023, Month.January, 10)).minutes.toInt()}
+            """.trimIndent()
+        )
+    }
+}
+
+fun CFArrayRef?.toStrArray(): Array<String?> {
+    val array = this
+
+    return Array(CFArrayGetCount(array).convert()) {
+        val ptr = CFArrayGetValueAtIndex(array, it.convert())
+        CFStringGetCStringPtr(ptr?.reinterpret(), kCFStringEncodingUTF8)?.toKStringFromUtf8()
+    }
+}

--- a/klock/src/darwinTest/kotlin/korlibs/time/internal/KlockInternalDarwinTest.kt
+++ b/klock/src/darwinTest/kotlin/korlibs/time/internal/KlockInternalDarwinTest.kt
@@ -1,6 +1,7 @@
 package korlibs.time.internal
 
 import korlibs.time.*
+import korlibs.time.darwin.*
 import kotlinx.cinterop.*
 import platform.CoreFoundation.*
 import kotlin.test.*
@@ -26,6 +27,14 @@ class KlockInternalDarwinTest {
                 CET: ${getLocalTimezoneOffsetDarwin(EuropeMadrid, DateTime(2023, Month.January, 10)).minutes.toInt()}
             """.trimIndent()
         )
+    }
+
+    @Test
+    fun testCFAbsoluteTime() {
+        assertEquals(0.0, DateTime.fromCFAbsoluteTime(0.0).cfAbsoluteTime())
+        assertEquals(1000.0, DateTime.fromCFAbsoluteTime(1000.0).cfAbsoluteTime())
+        assertEquals(-1000000.0, DateTime.fromCFAbsoluteTime(-1000000.0).cfAbsoluteTime())
+        assertEquals("Mon, 01 Jan 2001 00:00:00 UTC", DateTime.fromCFAbsoluteTime(0.0).toStringDefault())
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/korlibs/korge/issues/1587