### PR TITLE
Klock: Fixes Z parsing and adds DateTime.parseLocal as a shortcut for parse(str).local

### DIFF
--- a/klock/src/commonMain/kotlin/korlibs/time/DateFormat.kt
+++ b/klock/src/commonMain/kotlin/korlibs/time/DateFormat.kt
@@ -34,6 +34,7 @@ fun DateFormat.parse(str: String, doAdjust: Boolean = true): DateTimeTz =
 fun DateFormat.parseDate(str: String): Date = parse(str).local.date
 
 fun DateFormat.parseUtc(str: String): DateTime = parse(str).utc
+fun DateFormat.parseLocal(str: String): DateTime = parse(str).local
 
 fun DateFormat.format(date: Double): String = format(DateTime.fromUnixMillis(date))
 fun DateFormat.format(date: Long): String = format(DateTime.fromUnixMillis(date))

--- a/klock/src/commonMain/kotlin/korlibs/time/PatternDateFormat.kt
+++ b/klock/src/commonMain/kotlin/korlibs/time/PatternDateFormat.kt
@@ -102,7 +102,7 @@ data class PatternDateFormat @JvmOverloads constructor(
             "SSSSSSS" -> """(\d{7})"""
             "SSSSSSSS" -> """(\d{8})"""
             "SSSSSSSSS" -> """(\d{9})"""
-            "X", "XX", "XXX", "x", "xx", "xxx" -> """([\w:\+\-]+)"""
+            "X", "XX", "XXX", "x", "xx", "xxx", "Z" -> """([\w:\+\-]+)"""
             "a" -> """(\w+)"""
             " " -> """(\s+)"""
             else -> when {
@@ -244,24 +244,26 @@ data class PatternDateFormat @JvmOverloads constructor(
                         value.toInt()
                     }
                 }
-                "X", "XX", "XXX", "x", "xx", "xxx" -> when {
-                    name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
-                    name.startsWith("x") && value.first() == 'Z' -> {
-                        if (doThrow) throw RuntimeException("Zulu Time Zone is only accepted with X-XXX formats.") else return null
-                    }
-                    value.first() != 'Z' -> {
-                        val valueUnsigned = value.replace(":", "").removePrefix("-").removePrefix("+")
-                        val hours = when (name.length) {
-                            1 -> valueUnsigned.toInt()
-                            else -> valueUnsigned.take(2).toInt()
+                "X", "XX", "XXX", "x", "xx", "xxx" -> {
+                    when {
+                        name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
+                        name.startsWith("x") && value.first() == 'Z' -> {
+                            if (doThrow) throw RuntimeException("Zulu Time Zone is only accepted with X-XXX formats.") else return null
                         }
-                        val minutes = when (name.length) {
-                            1 -> 0
-                            else -> valueUnsigned.drop(2).toInt()
-                        }
-                        offset = hours.hours + minutes.minutes
-                        if (value.first() == '-') {
-                            offset = -offset
+                        value.first() != 'Z' -> {
+                            val valueUnsigned = value.replace(":", "").removePrefix("-").removePrefix("+")
+                            val hours = when (name.length) {
+                                1 -> valueUnsigned.toInt()
+                                else -> valueUnsigned.take(2).toInt()
+                            }
+                            val minutes = when (name.length) {
+                                1 -> 0
+                                else -> valueUnsigned.drop(2).toInt()
+                            }
+                            offset = hours.hours + minutes.minutes
+                            if (value.first() == '-') {
+                                offset = -offset
+                            }
                         }
                     }
                 }

--- a/klock/src/jvmTest/kotlin/korlibs/time/JvmReferenceTest.kt
+++ b/klock/src/jvmTest/kotlin/korlibs/time/JvmReferenceTest.kt
@@ -1,0 +1,46 @@
+package korlibs.time
+
+import java.time.*
+import java.time.format.*
+import kotlin.test.*
+
+class JvmReferenceTest {
+    fun jvmParse(
+        pattern: String,
+        dateString: String
+    ): Long {
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        val dateTime = LocalDateTime.parse(dateString, formatter);
+        val timestampMillis = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        return timestampMillis
+    }
+
+    fun klockParse(
+        pattern: String,
+        dateString: String
+    ): Long = DateFormat(pattern).parseUtc(dateString).unixMillisLong
+
+    @Test
+    fun testJvmParse() {
+        assertEquals(
+            1676679000000L,
+            jvmParse("EEE MMM dd HH:mm:ss Z yyyy", "Sat Feb 18 00:10:00 +0000 2023")
+        )
+        assertEquals(
+            1540124184000L,
+            jvmParse("EEE, dd MMM yyyy HH:mm:ss X", "Sun, 21 Oct 2018 12:16:24 +0300")
+        )
+    }
+
+    @Test
+    fun testKlockParse() {
+        assertEquals(
+            1676679000000L,
+            klockParse("EEE MMM dd HH:mm:ss Z yyyy", "Sat Feb 18 00:10:00 +0000 2023")
+        )
+        assertEquals(
+            1540124184000L,
+            klockParse("EEE, dd MMM yyyy HH:mm:ss X", "Sun, 21 Oct 2018 12:16:24 +0300")
+        )
+    }
+}

--- a/klock/src/jvmTest/kotlin/korlibs/time/JvmReferenceTest.kt
+++ b/klock/src/jvmTest/kotlin/korlibs/time/JvmReferenceTest.kt
@@ -18,7 +18,7 @@ class JvmReferenceTest {
     fun klockParse(
         pattern: String,
         dateString: String
-    ): Long = DateFormat(pattern).parseUtc(dateString).unixMillisLong
+    ): Long = DateFormat(pattern).parseLocal(dateString).unixMillisLong
 
     @Test
     fun testJvmParse() {
@@ -33,11 +33,15 @@ class JvmReferenceTest {
     }
 
     @Test
-    fun testKlockParse() {
+    fun testKlockParseZ() {
         assertEquals(
             1676679000000L,
             klockParse("EEE MMM dd HH:mm:ss Z yyyy", "Sat Feb 18 00:10:00 +0000 2023")
         )
+    }
+
+    @Test
+    fun testKlockParseX() {
         assertEquals(
             1540124184000L,
             klockParse("EEE, dd MMM yyyy HH:mm:ss X", "Sun, 21 Oct 2018 12:16:24 +0300")


### PR DESCRIPTION
Fixes https://github.com/korlibs/korge/issues/1632