### PR TITLE
Supports Orientation, Point.orientation, Point.polar & Angle with Y going down (inverted up vector)

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
+++ b/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
@@ -36,7 +36,7 @@ object RootKorlibsPlugin {
         rootProject.afterEvaluate {
             rootProject.allprojectsThis {
                 tasks.withType(Test::class.java) {
-                    it.ignoreFailures = true
+                    //it.ignoreFailures = true // This would cause the test to pass even if we have failing tests!
                 }
             }
         }

--- a/docs/korma/geometry/index.md
+++ b/docs/korma/geometry/index.md
@@ -13,27 +13,92 @@ KorMA provides some geometry utilities.
 
 ## Angle
 
-`Angle` is an inline class backed by a `Double` that represents an angle and that can give additional type safety and semantics to code. It can be constructed from and converted to `degrees` and `radians` and offer several utilities and operators related to angles:
+`Angle` is an inline class backed by a `Float` (when normalized being a ratio value between 0..1 instead of 0..PI2)
+that represents an angle and that can give additional type safety and semantics to code.
+It is stored as 0..1 to take advantage of this floating point range precision by using a Float.
+It can be constructed from and converted to `degrees` and `radians` and offer several
+utilities and operators related to angles:
+
+### Predefined angles:
 
 ```kotlin
-inline class Angle(val radians: Double)
+val EPSILON = Angle.fromRatio(0.00001f)
+val ZERO = 0.degrees
+val QUARTER = 90.degrees
+val HALF = 180.degrees
+val THREE_QUARTERS = 270.degrees
+val FULL = 360.degrees
+```
 
-fun cos(angle: Angle): Double
-fun sin(angle: Angle): Double
-fun tan(angle: Angle): Double
+### Constructing from ratio, radians or degrees
 
-inline val Number.degrees: Angle
-inline val Number.radians: Angle
+You can construct an Angle from a ratio, radians or degrees.
 
-val Angle.degrees: Double
-val Angle.radians: Double
+```kotlin
+val angle = Angle.fromRatio(0.5)
+val angle = Angle.fromRadians(PI)
+val angle = Angle.fromDegrees(180)
+```
 
+Or with numeric extension properties:
+
+```kotlin
+val angle = PI.radians
+val angle = 180.degrees
+```
+
+### Sine, Cosine & Tangent 
+
+You can get the cosine (X), sine (Y) or tangent (Y/X) with:
+
+```kotlin
+fun cos(angle: Angle, up: Vector2 = Vector2.UP): Float
+fun sin(angle: Angle, up: Vector2 = Vector2.UP): Float
+fun tan(angle: Angle, up: Vector2 = Vector2.UP): Float
+```
+
+```kotlin
+val x = angle.cosine
+val y = angle.sine
+val tan = angle.tangent
+```
+
+Since in KorGE, coordinates are X+ right, and Y+ down, while typical Y+ is up, you can provide a parameter to cosine to specify
+the vector representing up or what value would have y for 90.degrees:
+
+```kotlin
+val x = angle.cosine(Vector2.UP_SCREEN)
+val y = angle.sine(Vector2.UP_SCREEN)
+val tan = angle.tangent(Vector2.UP_SCREEN)
+```
+
+There are two standard provided up vectors `Vector2.UP` (Y+ up) and `Vector2.UP_SCREEN` (Y+ down)
+
+### Normalizing angle
+
+```kotlin
 val Angle.normalized: Angle
 ```
 
 ## Point and Matrix
 
 `Point` and `Matrix` are classes holding doubles (to get consistency among targets including JavaScript) that represent a 2D Point (with x and y) and a 2D Affine Transform Matrix (with a, b, c, d, tx and ty).
+Point is a typealias of `Vector2`.
+
+## Vector2
+
+### Polar coordinates
+
+You can construct a Vector2/Point from polar coordinates like:
+
+```kotlin
+Point.polar(Point(100, 100), 45.degrees, 50f, up = Vector2.UP_SCREEN) // (135.35535, 64.64466)
+Point.polar(Point(100, 100), 45.degrees, 50f, up = Vector2.UP)        // (135.35535, 135.35535)
+Point.polar(Point(100, 100), 45.degrees, 50f)                         // (135.35535, 135.35535)
+```
+
+The up vector is to determine where the up is, since by default it is going to be Y+ up,
+and that would be interpreted differently for drawn points in the case of KorGE since Y+ is down.
 
 ## Vector3D and Matrix3D
 

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Angle.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Angle.kt
@@ -46,16 +46,14 @@ import kotlin.math.*
  *
  * The equivalent old [Angle] constructor is now [Angle.fromRadians]
  *
- * In a reference system where X+ is right Y+ is up, angle cosines/sines angles advance counter-clock-wise:
- * * cosine(Vector2.UP), sine(Vector2.UP)
+ * Angles advance counter-clock-wise, starting with 0.degrees representing the right vector:
  *
- * 0.degrees represent right: cosine=1 sine=0
- * 90.degrees represents up: cosine=0 sine=1
- * 180.degrees represents left: cosine=-1 sine=0
- * 270.degrees represents down: cosine=0 sine=-1
+ * Depending on what the up vector means, then numeric values of sin might be negated.
  *
- * In a reference system where X+ is right, and Y+ is down, angle cosines/sines angles advance clock-wise:
- * * cosine(Vector2.SCREEN_UP), sine(Vector2.SCREEN_UP)
+ *   0.degrees represent right:    up=Vector2.UP: cos =+1, sin= 0 || up=Vector2.UP_SCREEN: cos =+1, sin= 0
+ *  90.degrees represents up:      up=Vector2.UP: cos = 0, sin=+1 || up=Vector2.UP_SCREEN: cos = 0, sin=-1
+ * 180.degrees represents left:    up=Vector2.UP: cos =-1, sin= 0 || up=Vector2.UP_SCREEN: cos =-1, sin= 0
+ * 270.degrees represents down:    up=Vector2.UP: cos = 0, sin=-1 || up=Vector2.UP_SCREEN: cos = 0, sin=+1
  */
 //@KormaValueApi
 inline class Angle @PublishedApi internal constructor(

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Orientation.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Orientation.kt
@@ -30,9 +30,12 @@ enum class Orientation(val value: Int) {
         //}
 
         // @TODO: Should we provide an UP vector as reference instead? ie. Vector2(0, +1) or Vector2(0, -1), would make sense for 3d?
-        fun orient2d(pa: Point, pb: Point, pc: Point, yGoesUp: Boolean = true): Orientation = orient2d(pa.xD, pa.yD, pb.xD, pb.yD, pc.xD, pc.yD, yGoesUp = yGoesUp)
+        fun orient2d(pa: Point, pb: Point, pc: Point, up: Vector2 = Vector2.UP): Orientation {
+            return orient2d(pa.xD, pa.yD, pb.xD, pb.yD, pc.xD, pc.yD, up = up)
+        }
 
-        fun orient2d(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON, yGoesUp: Boolean = true): Orientation {
+        fun orient2d(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON, up: Vector2 = Vector2.UP): Orientation {
+            check(up.x == 0f && up.y.absoluteValue == 1f) { "up vector only supports (0, -1) and (0, +1) for now" }
             // Cross product
             val detleft: Double = (paX - pcX) * (pbY - pcY)
             val detright: Double = (paY - pcY) * (pbX - pcX)
@@ -43,14 +46,14 @@ enum class Orientation(val value: Int) {
                 v > 0 -> COUNTER_CLOCK_WISE
                 else -> CLOCK_WISE
             }
-            return if (yGoesUp) res else -res
+            return if (up.y > 0) res else -res
         }
 
         @Deprecated("", ReplaceWith(
-            "orient2d(paX, paY, pbX, pbY, pcX, pcY, epsilon, yGoesUp = false)",
+            "orient2d(paX, paY, pbX, pbY, pcX, pcY, epsilon, up = Vector2.UP_SCREEN)",
             "korlibs.math.geom.Orientation.Companion.orient2d"
         ))
         fun orient2dFixed(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON): Orientation =
-            orient2d(paX, paY, pbX, pbY, pcX, pcY, epsilon, yGoesUp = false)
+            orient2d(paX, paY, pbX, pbY, pcX, pcY, epsilon, up = Vector2.UP_SCREEN)
     }
 }

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Orientation.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Orientation.kt
@@ -29,13 +29,17 @@ enum class Orientation(val value: Int) {
         //    }
         //}
 
+        internal fun checkValidUpVector(up: Vector2) {
+            check(up.x == 0f && up.y.absoluteValue == 1f) { "up vector only supports (0, -1) and (0, +1) for now" }
+        }
+
         // @TODO: Should we provide an UP vector as reference instead? ie. Vector2(0, +1) or Vector2(0, -1), would make sense for 3d?
         fun orient2d(pa: Point, pb: Point, pc: Point, up: Vector2 = Vector2.UP): Orientation {
             return orient2d(pa.xD, pa.yD, pb.xD, pb.yD, pc.xD, pc.yD, up = up)
         }
 
         fun orient2d(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON, up: Vector2 = Vector2.UP): Orientation {
-            check(up.x == 0f && up.y.absoluteValue == 1f) { "up vector only supports (0, -1) and (0, +1) for now" }
+            checkValidUpVector(up)
             // Cross product
             val detleft: Double = (paX - pcX) * (pbY - pcY)
             val detright: Double = (paY - pcY) * (pbX - pcX)

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Orientation.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Orientation.kt
@@ -5,6 +5,13 @@ import kotlin.math.*
 enum class Orientation(val value: Int) {
     CLOCK_WISE(+1), COUNTER_CLOCK_WISE(-1), COLLINEAR(0);
 
+    operator fun unaryMinus(): Orientation = when (this) {
+        CLOCK_WISE -> COUNTER_CLOCK_WISE
+        COUNTER_CLOCK_WISE -> CLOCK_WISE
+        COLLINEAR -> COLLINEAR
+    }
+    operator fun unaryPlus(): Orientation = this
+
     companion object {
         private const val EPSILONf: Float = 1e-4f
         private const val EPSILON: Double = 1e-7
@@ -22,30 +29,28 @@ enum class Orientation(val value: Int) {
         //    }
         //}
 
-        fun orient2d(pa: Point, pb: Point, pc: Point): Orientation = orient2d(pa.xD, pa.yD, pb.xD, pb.yD, pc.xD, pc.yD)
+        // @TODO: Should we provide an UP vector as reference instead? ie. Vector2(0, +1) or Vector2(0, -1), would make sense for 3d?
+        fun orient2d(pa: Point, pb: Point, pc: Point, yGoesUp: Boolean = true): Orientation = orient2d(pa.xD, pa.yD, pb.xD, pb.yD, pc.xD, pc.yD, yGoesUp = yGoesUp)
 
-        fun orient2d(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON): Orientation {
+        fun orient2d(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON, yGoesUp: Boolean = true): Orientation {
+            // Cross product
             val detleft: Double = (paX - pcX) * (pbY - pcY)
             val detright: Double = (paY - pcY) * (pbX - pcX)
             val v: Double = detleft - detright
 
-            return when {
+            val res: Orientation = when {
                 v.absoluteValue < epsilon -> COLLINEAR
                 v > 0 -> COUNTER_CLOCK_WISE
                 else -> CLOCK_WISE
             }
+            return if (yGoesUp) res else -res
         }
 
-        fun orient2dFixed(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double): Orientation {
-            val detleft: Double = (paX - pcX) * (pbY - pcY)
-            val detright: Double = (paY - pcY) * (pbX - pcX)
-            val v: Double = detleft - detright
-
-            return when {
-                (v > -EPSILON) && (v < EPSILON) -> COLLINEAR
-                v > 0 -> CLOCK_WISE
-                else -> COUNTER_CLOCK_WISE
-            }
-        }
+        @Deprecated("", ReplaceWith(
+            "orient2d(paX, paY, pbX, pbY, pcX, pcY, epsilon, yGoesUp = false)",
+            "korlibs.math.geom.Orientation.Companion.orient2d"
+        ))
+        fun orient2dFixed(paX: Double, paY: Double, pbX: Double, pbY: Double, pcX: Double, pcY: Double, epsilon: Double = EPSILON): Orientation =
+            orient2d(paX, paY, pbX, pbY, pcX, pcY, epsilon, yGoesUp = false)
     }
 }

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Vector2.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Vector2.kt
@@ -100,8 +100,9 @@ data class Vector2(val x: Float, val y: Float) {
     infix fun cross(that: Vector2): Float = crossProduct(this, that)
     infix fun dot(that: Vector2): Float = ((this.x * that.x) + (this.y * that.y))
 
-    fun angleTo(other: Vector2): Angle = Angle.between(this.x, this.y, other.x, other.y)
-    val angle: Angle get() = Angle.between(0f, 0f, this.x, this.y)
+    fun angleTo(other: Vector2, up: Vector2 = UP): Angle = Angle.between(this.x, this.y, other.x, other.y, up)
+    val angle: Angle get() = angle()
+    fun angle(up: Vector2 = UP): Angle = Angle.between(0f, 0f, this.x, this.y, up)
 
     inline fun deltaTransformed(m: Matrix): Vector2 = m.deltaTransform(this)
     inline fun transformed(m: Matrix): Vector2 = m.transform(this)
@@ -135,9 +136,9 @@ data class Vector2(val x: Float, val y: Float) {
     val intRound: Vector2Int get() = Vector2Int(x.roundToInt(), y.roundToInt())
 
     fun roundDecimalPlaces(places: Int): Vector2 = Point(x.roundDecimalPlaces(places), y.roundDecimalPlaces(places))
-    fun round(): Vector2 = Point(kotlin.math.round(x), kotlin.math.round(y))
-    fun ceil(): Vector2 = Point(kotlin.math.ceil(x), kotlin.math.ceil(y))
-    fun floor(): Vector2 = Point(kotlin.math.floor(x), kotlin.math.floor(y))
+    fun round(): Vector2 = Point(round(x), round(y))
+    fun ceil(): Vector2 = Point(ceil(x), ceil(y))
+    fun floor(): Vector2 = Point(floor(x), floor(y))
 
     //fun copy(x: Double = this.x, y: Double = this.y): Vector2 = Point(x, y)
 
@@ -188,26 +189,26 @@ data class Vector2(val x: Float, val y: Float) {
 
         //fun fromRaw(raw: Float2Pack) = Point(raw)
 
-        /** Constructs a point from polar coordinates determined by an [angle] and a [length]. Angle 0 is pointing to the right, and the direction is counter-clock-wise */
-        inline fun polar(x: Float, y: Float, angle: Angle, length: Float = 1f): Vector2 = Point(x + angle.cosineF * length, y + angle.sineF * length)
-        inline fun polar(x: Double, y: Double, angle: Angle, length: Float = 1f): Vector2 = Point(x + angle.cosineD * length, y + angle.sineD * length)
-        inline fun polar(base: Vector2, angle: Angle, length: Float = 1f): Vector2 = polar(base.x, base.y, angle, length)
-        inline fun polar(angle: Angle, length: Float = 1f): Vector2 = polar(0.0, 0.0, angle, length)
+        /** Constructs a point from polar coordinates determined by an [angle] and a [length]. Angle 0 is pointing to the right, and the direction is counter-clock-wise for up=UP and clock-wise for up=UP_SCREEN */
+        inline fun polar(x: Float, y: Float, angle: Angle, length: Float = 1f, up: Vector2 = UP): Vector2 = Point(x + angle.cosineF(up) * length, y + angle.sineF(up) * length)
+        inline fun polar(x: Double, y: Double, angle: Angle, length: Float = 1f, up: Vector2 = UP): Vector2 = Point(x + angle.cosineD(up) * length, y + angle.sineD(up) * length)
+        inline fun polar(base: Vector2, angle: Angle, length: Float = 1f, up: Vector2 = UP): Vector2 = polar(base.x, base.y, angle, length, up)
+        inline fun polar(angle: Angle, length: Float = 1f, up: Vector2 = UP): Vector2 = polar(0.0, 0.0, angle, length, up)
 
         inline fun middle(a: Vector2, b: Vector2): Vector2 = (a + b) * 0.5
 
-        fun angle(ax: Double, ay: Double, bx: Double, by: Double): Angle = Angle.between(ax, ay, bx, by)
-        fun angle(x1: Double, y1: Double, x2: Double, y2: Double, x3: Double, y3: Double): Angle = Angle.between(x1 - x2, y1 - y2, x1 - x3, y1 - y3)
+        fun angle(ax: Double, ay: Double, bx: Double, by: Double, up: Vector2 = UP): Angle = Angle.between(ax, ay, bx, by, up)
+        fun angle(x1: Double, y1: Double, x2: Double, y2: Double, x3: Double, y3: Double, up: Vector2 = UP): Angle = Angle.between(x1 - x2, y1 - y2, x1 - x3, y1 - y3, up)
 
-        fun angle(a: Vector2, b: Vector2): Angle = Angle.between(a, b)
-        fun angle(p1: Vector2, p2: Vector2, p3: Vector2): Angle = Angle.between(p1 - p2, p1 - p3)
+        fun angle(a: Vector2, b: Vector2, up: Vector2 = UP): Angle = Angle.between(a, b, up)
+        fun angle(p1: Vector2, p2: Vector2, p3: Vector2, up: Vector2 = UP): Angle = Angle.between(p1 - p2, p1 - p3, up)
 
-        fun angleArc(a: Vector2, b: Vector2): Angle = Angle.fromRadians(acos((a dot b) / (a.length * b.length)))
-        fun angleFull(a: Vector2, b: Vector2): Angle = Angle.between(a, b)
+        fun angleArc(a: Vector2, b: Vector2, up: Vector2 = UP): Angle = Angle.fromRadians(acos((a dot b) / (a.length * b.length))).adjustFromUp(up)
+        fun angleFull(a: Vector2, b: Vector2, up: Vector2 = UP): Angle = Angle.between(a, b, up)
 
-        fun distance(a: Double, b: Double): Double = kotlin.math.abs(a - b)
-        fun distance(x1: Double, y1: Double, x2: Double, y2: Double): Double = kotlin.math.hypot(x1 - x2, y1 - y2)
-        fun distance(x1: Float, y1: Float, x2: Float, y2: Float): Float = kotlin.math.hypot(x1 - x2, y1 - y2)
+        fun distance(a: Double, b: Double): Double = abs(a - b)
+        fun distance(x1: Double, y1: Double, x2: Double, y2: Double): Double = hypot(x1 - x2, y1 - y2)
+        fun distance(x1: Float, y1: Float, x2: Float, y2: Float): Float = hypot(x1 - x2, y1 - y2)
         fun distance(x1: Int, y1: Int, x2: Int, y2: Int): Float = distance(x1.toFloat(), y1.toFloat(), x2.toFloat(), y2.toFloat())
         fun distance(a: Vector2, b: Vector2): Float = distance(a.x, a.y, b.x, b.y)
         fun distance(a: Vector2Int, b: Vector2Int): Float = distance(a.x, a.y, b.x, b.y)
@@ -218,6 +219,7 @@ data class Vector2(val x: Float, val y: Float) {
         fun distanceSquared(x1: Float, y1: Float, x2: Float, y2: Float): Float = square(x1 - x2) + square(y1 - y2)
         fun distanceSquared(x1: Int, y1: Int, x2: Int, y2: Int): Int = square(x1 - x2) + square(y1 - y2)
 
+        @Deprecated("Likely searching for orientation")
         inline fun direction(a: Vector2, b: Vector2): Vector2 = b - a
 
         fun compare(l: Vector2, r: Vector2): Int = compare(l.x, l.y, r.x, r.y)
@@ -262,14 +264,16 @@ data class Vector2(val x: Float, val y: Float) {
 
         // https://algorithmtutor.com/Computational-Geometry/Determining-if-two-consecutive-segments-turn-left-or-right/
         /** < 0 left, > 0 right, 0 collinear */
-        fun orientation(p1: Vector2, p2: Vector2, p3: Vector2, yGoesUp: Boolean = true): Float = orientation(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, yGoesUp)
-        fun orientation(ax: Float, ay: Float, bx: Float, by: Float, cx: Float, cy: Float, yGoesUp: Boolean = true): Float {
+        fun orientation(p1: Vector2, p2: Vector2, p3: Vector2, up: Vector2 = UP): Float = orientation(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, up)
+        fun orientation(ax: Float, ay: Float, bx: Float, by: Float, cx: Float, cy: Float, up: Vector2 = UP): Float {
+            Orientation.checkValidUpVector(up)
             val res = crossProduct(cx - ax, cy - ay, bx - ax, by - ay)
-            return if (yGoesUp) res else -res
+            return if (up.y > 0f) res else -res
         }
-        fun orientation(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double, yGoesUp: Boolean = true): Double {
+        fun orientation(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double, up: Vector2 = UP): Double {
+            Orientation.checkValidUpVector(up)
             val res = crossProduct(cx - ax, cy - ay, bx - ax, by - ay)
-            return if (yGoesUp) res else -res
+            return if (up.y > 0f) res else -res
         }
 
         fun crossProduct(ax: Float, ay: Float, bx: Float, by: Float): Float = (ax * by) - (bx * ay)

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Vector2.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Vector2.kt
@@ -246,9 +246,15 @@ data class Vector2(val x: Float, val y: Float) {
 
         // https://algorithmtutor.com/Computational-Geometry/Determining-if-two-consecutive-segments-turn-left-or-right/
         /** < 0 left, > 0 right, 0 collinear */
-        fun orientation(p1: Vector2, p2: Vector2, p3: Vector2): Float = orientation(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y)
-        fun orientation(ax: Float, ay: Float, bx: Float, by: Float, cx: Float, cy: Float): Float = crossProduct(cx - ax, cy - ay, bx - ax, by - ay)
-        fun orientation(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double): Double = crossProduct(cx - ax, cy - ay, bx - ax, by - ay)
+        fun orientation(p1: Vector2, p2: Vector2, p3: Vector2, yGoesUp: Boolean = true): Float = orientation(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, yGoesUp)
+        fun orientation(ax: Float, ay: Float, bx: Float, by: Float, cx: Float, cy: Float, yGoesUp: Boolean = true): Float {
+            val res = crossProduct(cx - ax, cy - ay, bx - ax, by - ay)
+            return if (yGoesUp) res else -res
+        }
+        fun orientation(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double, yGoesUp: Boolean = true): Double {
+            val res = crossProduct(cx - ax, cy - ay, bx - ax, by - ay)
+            return if (yGoesUp) res else -res
+        }
 
         fun crossProduct(ax: Float, ay: Float, bx: Float, by: Float): Float = (ax * by) - (bx * ay)
         fun crossProduct(ax: Double, ay: Double, bx: Double, by: Double): Double = (ax * by) - (bx * ay)

--- a/korma/src/commonMain/kotlin/korlibs/math/geom/Vector2.kt
+++ b/korma/src/commonMain/kotlin/korlibs/math/geom/Vector2.kt
@@ -167,6 +167,22 @@ data class Vector2(val x: Float, val y: Float) {
         val ZERO = Point(0f, 0f)
         val NaN = Point(Float.NaN, Float.NaN)
 
+        /** Mathematically typical LEFT, matching screen coordinates (-1, 0) */
+        val LEFT = Point(-1f, 0f)
+        /** Mathematically typical RIGHT, matching screen coordinates (+1, 0) */
+        val RIGHT = Point(+1f, 0f)
+
+        /** Mathematically typical UP (0, +1) */
+        val UP = Point(0f, +1f)
+        /** UP using screen coordinates as reference (0, -1) */
+        val UP_SCREEN = Point(0f, -1f)
+
+        /** Mathematically typical DOWN (0, -1) */
+        val DOWN = Point(0f, -1f)
+        /** DOWN using screen coordinates as reference (0, +1) */
+        val DOWN_SCREEN = Point(0f, +1f)
+
+
         //inline operator fun invoke(x: Int, y: Int): Vector2 = Point(x.toDouble(), y.toDouble())
         //inline operator fun invoke(x: Float, y: Float): Vector2 = Point(x.toDouble(), y.toDouble())
 

--- a/korma/src/commonTest/kotlin/korlibs/math/geom/AngleTest.kt
+++ b/korma/src/commonTest/kotlin/korlibs/math/geom/AngleTest.kt
@@ -162,4 +162,31 @@ class AngleTest {
         assertEquals(180.degrees, Ratio.HALF.interpolateAngleDenormalized(350.degrees, (10).degrees))
         assertEquals(180.degrees, Ratio.HALF.interpolateAngleDenormalized(10.degrees, (350).degrees))
     }
+
+    @Test
+    fun testReferenceSystem() {
+        run {
+            assertEqualsFloat(listOf(1f, 0f), listOf(Angle.ZERO.cosine(), Angle.ZERO.sine()))
+            assertEqualsFloat(listOf(0f, 1f), listOf(Angle.QUARTER.cosine(), Angle.QUARTER.sine()))
+            assertEqualsFloat(listOf(-1f, 0f), listOf(Angle.HALF.cosine(), Angle.HALF.sine()))
+            assertEqualsFloat(listOf(0f, -1f), listOf(Angle.THREE_QUARTERS.cosine(), Angle.THREE_QUARTERS.sine()))
+        }
+        run {
+            val up = Vector2.UP
+            assertEqualsFloat(listOf(1f, 0f), listOf(Angle.ZERO.cosine(up), Angle.ZERO.sine(up)))
+            assertEqualsFloat(listOf(0f, 1f), listOf(Angle.QUARTER.cosine(up), Angle.QUARTER.sine(up)))
+            assertEqualsFloat(listOf(-1f, 0f), listOf(Angle.HALF.cosine(up), Angle.HALF.sine(up)))
+            assertEqualsFloat(listOf(0f, -1f), listOf(Angle.THREE_QUARTERS.cosine(up), Angle.THREE_QUARTERS.sine(up)))
+        }
+        run {
+            val up = Vector2.UP_SCREEN
+            assertEqualsFloat(listOf(1f, 0f), listOf(Angle.ZERO.cosine(up), Angle.ZERO.sine(up)))
+            assertEqualsFloat(listOf(0f, -1f), listOf(Angle.QUARTER.cosine(up), Angle.QUARTER.sine(up)))
+            assertEqualsFloat(listOf(-1f, 0f), listOf(Angle.HALF.cosine(up), Angle.HALF.sine(up)))
+            assertEqualsFloat(listOf(0f, +1f), listOf(Angle.THREE_QUARTERS.cosine(up), Angle.THREE_QUARTERS.sine(up)))
+        }
+        assertEqualsFloat(listOf(0.0, 1.0), listOf(Angle.QUARTER.cosineD(), Angle.QUARTER.sineD()))
+        assertEqualsFloat(listOf(0.0, 1.0), listOf(Angle.QUARTER.cosineD(Vector2.UP), Angle.QUARTER.sineD(Vector2.UP)))
+        assertEqualsFloat(listOf(0.0, -1.0), listOf(Angle.QUARTER.cosineD(Vector2.UP_SCREEN), Angle.QUARTER.sineD(Vector2.UP_SCREEN)))
+    }
 }

--- a/korma/src/commonTest/kotlin/korlibs/math/geom/OrientationTest.kt
+++ b/korma/src/commonTest/kotlin/korlibs/math/geom/OrientationTest.kt
@@ -14,7 +14,7 @@ class OrientationTest {
     @Test
     fun testOrientation() {
         assertEquals(Orientation.CLOCK_WISE, Orientation.orient2d(Point(0, 0), Point(0, 100), Point(100, 0)))
-        assertEquals(Orientation.COUNTER_CLOCK_WISE, Orientation.orient2d(Point(0, 0), Point(0, 100), Point(100, 0), yGoesUp = false))
+        assertEquals(Orientation.COUNTER_CLOCK_WISE, Orientation.orient2d(Point(0, 0), Point(0, 100), Point(100, 0), up = Vector2.UP_SCREEN))
     }
 
 

--- a/korma/src/commonTest/kotlin/korlibs/math/geom/OrientationTest.kt
+++ b/korma/src/commonTest/kotlin/korlibs/math/geom/OrientationTest.kt
@@ -11,6 +11,13 @@ class OrientationTest {
         assertEquals(Orientation.COLLINEAR, Orientation.orient2d(Point(0, 0), Point(5, 0), Point(10, 0)))
     }
 
+    @Test
+    fun testOrientation() {
+        assertEquals(Orientation.CLOCK_WISE, Orientation.orient2d(Point(0, 0), Point(0, 100), Point(100, 0)))
+        assertEquals(Orientation.COUNTER_CLOCK_WISE, Orientation.orient2d(Point(0, 0), Point(0, 100), Point(100, 0), yGoesUp = false))
+    }
+
+
     //@Test
     //fun test3D() {
     //    assertEquals(Orientation.COUNTER_CLOCK_WISE, Orientation.orient3d(Vector3.ZERO, Vector3.UP, Vector3.RIGHT))

--- a/korma/src/commonTest/kotlin/korlibs/math/geom/PointTest.kt
+++ b/korma/src/commonTest/kotlin/korlibs/math/geom/PointTest.kt
@@ -35,6 +35,12 @@ class PointTest {
         assertEquals(Point(4, 6), Point(1, 2) + Point(3, 4))
     }
 
+    @Test
+    fun testPolarConstruction() {
+        assertEqualsFloat(Point(10, 20), Point.polar(Point(10, 10), 90.degrees, 10f, up = Vector2.UP))
+        assertEqualsFloat(Point(10, 0), Point.polar(Point(10, 10), 90.degrees, 10f, up = Vector2.UP_SCREEN))
+    }
+
     private fun assertEquals(a: Point, b: Point, absoluteTolerance: Float = 1e-7f) {
         assertTrue("Point $a != $b absoluteTolerance=$absoluteTolerance") {
             a.x.isAlmostEquals(b.x, absoluteTolerance) &&


### PR DESCRIPTION
We will need to do the same with Angle.between & Point.angleTo. Maybe alternatively we could provide a UP vector as reference, so it is even more generic.

Fixes https://github.com/korlibs/korge/issues/1062

@Kietyo 