### PR TITLE
Remove it.ignoreFailures & fixes tests on CI

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
+++ b/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
@@ -36,7 +36,7 @@ object RootKorlibsPlugin {
         rootProject.afterEvaluate {
             rootProject.allprojectsThis {
                 tasks.withType(Test::class.java) {
-                    it.ignoreFailures = true
+                    //it.ignoreFailures = true // This would cause the test to pass even if we have failing tests!
                 }
             }
         }

--- a/korim/src/darwinMain/kotlin/korlibs/image/format/cg/CGNativeImageFormatProvider.kt
+++ b/korim/src/darwinMain/kotlin/korlibs/image/format/cg/CGNativeImageFormatProvider.kt
@@ -44,7 +44,6 @@ open class CGNativeImageFormatProvider : CGBaseNativeImageFormatProvider() {
                 }
             }
         }
-
     }
 
     //override fun createBitmapNativeImage(bmp: Bitmap) = BitmapNativeImage(bmp.toBMP32().premultipliedIfRequired())

--- a/korim/src/jvmTest/kotlin/korlibs/image/format/ImageFormatsNativeTest.kt
+++ b/korim/src/jvmTest/kotlin/korlibs/image/format/ImageFormatsNativeTest.kt
@@ -48,14 +48,4 @@ class ImageFormatsNativeTest {
         //showImageAndWait(bitmap)
         //File("c:/temp/logosvg.png").toVfs().writeBitmap(bitmap.toBMP32())
     }
-
-    @Test
-    fun testCoreGraphicsOnMac() = suspendTest {
-        if (!Platform.isMac) return@suspendTest
-
-        println(CoreGraphicsImageFormatProvider().decode(resourcesVfs["kotlin8.png"]))
-        println(measureTime {
-            CoreGraphicsImageFormatProvider().decode(localVfs("/Users/soywiz/projects/glTF-Sample-Models/2.0/ABeautifulGame/glTF/King_black_normal.jpg"))
-        })
-    }
 }


### PR DESCRIPTION
This was mistakenly added when trying get wasm working. The idea adding it could allow other tests to continue running and see all the errors at once to report them. But this affected other targets as well, and it was not reverted later.