### PR TITLE
add option for undecorated AWT window

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidMainActivityKt.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidMainActivityKt.kt
@@ -10,7 +10,7 @@ object AndroidMainActivityKt {
         line("import korlibs.render.*")
         line("import ${config.realEntryPoint}")
 
-        line("class MainActivity : KorgwActivity(config = GameWindowCreationConfig(msaa = ${config.androidMsaa ?: 1}, fullscreen = ${config.fullscreen}))") {
+        line("class MainActivity : KorgwActivity(config = GameWindowCreationConfig(msaa = ${config.androidMsaa ?: 1}, windowConfig = WindowConfig(fullscreen = ${config.fullscreen})))") {
             line("override suspend fun activityMain()") {
                 //line("withAndroidContext(this)") { // @TODO: Probably we should move this to KorgwActivity itself
                 for (text in config.androidInit) {

--- a/korge/src/commonMain/kotlin/korlibs/korge/Korge.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/Korge.kt
@@ -59,7 +59,8 @@ suspend fun Korge(
     debug: Boolean = false,
     trace: Boolean = false,
     context: Any? = null,
-    fullscreen: Boolean? = null,
+    @DeprecatedParameter("Use WindowConfig instead") fullscreen: Boolean = false,
+    windowConfig: WindowConfig = WindowConfig(),
     blocking: Boolean = true,
     gameId: String = Korge.DEFAULT_GAME_ID,
     settingsFolder: String? = null,
@@ -93,8 +94,8 @@ suspend fun Korge(
 ): Unit = Korge(
     args = args, imageFormats = imageFormats, gameWindow = gameWindow, mainSceneClass = mainSceneClass,
     timeProvider = timeProvider, injector = injector, configInjector = configInjector, debug = debug,
-    trace = trace, context = context, fullscreen = fullscreen, blocking = blocking, gameId = gameId,
-    settingsFolder = settingsFolder, batchMaxQuads = batchMaxQuads,
+    trace = trace, context = context, windowConfig = windowConfig, blocking = blocking,
+    gameId = gameId, settingsFolder = settingsFolder, batchMaxQuads = batchMaxQuads,
     windowSize = windowSize, virtualSize = virtualSize,
     displayMode = displayMode, title = title, backgroundColor = backgroundColor, quality = quality,
     icon = icon,
@@ -121,7 +122,7 @@ data class Korge(
     val debug: Boolean = false,
     val trace: Boolean = false,
     val context: Any? = null,
-    val fullscreen: Boolean? = null,
+    val windowConfig : WindowConfig = WindowConfig(),
     val blocking: Boolean = true,
     val gameId: String = DEFAULT_GAME_ID,
     val settingsFolder: String? = null,
@@ -178,7 +179,7 @@ object KorgeRunner {
         if (!Platform.isJsBrowser) {
             configureLoggerFromProperties(localCurrentDirVfs["klogger.properties"])
         }
-        val realGameWindow = (config.gameWindow ?: coroutineContext[GameWindow] ?: CreateDefaultGameWindow(GameWindowCreationConfig(multithreaded = multithreaded, fullscreen = config.fullscreen)))
+        val realGameWindow = (config.gameWindow ?: coroutineContext[GameWindow] ?: CreateDefaultGameWindow(GameWindowCreationConfig(multithreaded = multithreaded, windowConfig = config.windowConfig)))
         realGameWindow.bgcolor = config.backgroundColor ?: Colors.BLACK
         //println("Configure: ${width}x${height}")
         // @TODO: Configure should happen before loop. But we should ensure that all the korgw targets are ready for this
@@ -187,7 +188,7 @@ object KorgeRunner {
             val gameWindow = this
             if (Platform.isNative) println("Korui[0]")
             gameWindow.registerTime("configureGameWindow") {
-                realGameWindow.configure(windowSize, config.title, null, config.fullscreen, config.backgroundColor ?: Colors.BLACK)
+                realGameWindow.configure(windowSize, config.title, null, config.windowConfig, config.backgroundColor ?: Colors.BLACK)
             }
             gameWindow.registerTime("setIcon") {
                 try {

--- a/korgw/src/commonMain/kotlin/korlibs/render/GameWindow.kt
+++ b/korgw/src/commonMain/kotlin/korlibs/render/GameWindow.kt
@@ -29,6 +29,14 @@ import kotlin.properties.*
 @ThreadLocal
 var GLOBAL_CHECK_GL = false
 
+data class WindowConfig(
+        val fullscreen : Boolean = false,
+        val undecorated : Boolean = false,
+        val transparent : Boolean = false,
+        val allowMinimize : Boolean = true,
+        val allowMaximize : Boolean = true,
+)
+
 data class GameWindowCreationConfig(
     val multithreaded: Boolean? = null,
     val hdr: Boolean? = null,
@@ -36,7 +44,7 @@ data class GameWindowCreationConfig(
     val checkGl: Boolean = false,
     val logGl: Boolean = false,
     val cacheGl: Boolean = false,
-    val fullscreen: Boolean? = null,
+    val windowConfig : WindowConfig = WindowConfig()
 )
 
 expect fun CreateDefaultGameWindow(config: GameWindowCreationConfig): GameWindow
@@ -959,16 +967,16 @@ fun GameWindow.mainLoop(entry: suspend GameWindow.() -> Unit) = Korio { loop(ent
 fun GameWindow.toggleFullScreen()  { fullscreen = !fullscreen }
 
 fun GameWindow.configure(
-    size: Size,
-    title: String? = "GameWindow",
-    icon: Bitmap? = null,
-    fullscreen: Boolean? = null,
-    bgcolor: RGBA = Colors.BLACK,
+        size: Size,
+        title: String? = "GameWindow",
+        icon: Bitmap? = null,
+        windowConfig: WindowConfig= WindowConfig(),
+        bgcolor: RGBA = Colors.BLACK,
 ) {
     this.setSize(size.width.toInt(), size.height.toInt())
     if (title != null) this.title = title
     this.icon = icon
-    if (fullscreen != null) this.fullscreen = fullscreen
+    if (fullscreen != null) this.fullscreen = windowConfig.fullscreen
     this.bgcolor = bgcolor
     this.visible = true
 }

--- a/korgw/src/jvmMain/kotlin/korlibs/render/awt/AwtGameWindow.kt
+++ b/korgw/src/jvmMain/kotlin/korlibs/render/awt/AwtGameWindow.kt
@@ -60,6 +60,7 @@ class AwtGameWindow(config: GameWindowCreationConfig) : BaseAwtGameWindow(AGOpen
         init {
             isVisible = false
             ignoreRepaint = true
+            isUndecorated = config.windowConfig.undecorated
             //background = Color.black
             setBounds(0, 0, 640, 480)
             val frame = this


### PR DESCRIPTION
Adds a flag for creating an undecorated window. Currently, only meaningful for AWT windows.