### PR TITLE
Fix blurry DefaultTtfFontAsBitmap text in CachedContainer when virtual size < window size

### DIFF
--- a/korge-sandbox/src/commonMain/kotlin/samples/MainCache.kt
+++ b/korge-sandbox/src/commonMain/kotlin/samples/MainCache.kt
@@ -6,19 +6,28 @@ import korlibs.korge.time.*
 import korlibs.korge.ui.*
 import korlibs.korge.view.*
 import korlibs.image.color.*
+import korlibs.image.font.*
+import korlibs.image.text.*
+import korlibs.korge.*
+import korlibs.math.geom.*
 import korlibs.math.interpolation.*
 import korlibs.math.random.*
+import korlibs.memory.*
 import kotlin.random.*
 
 //class MainCache : ScaledScene(512, 512) {
 class MainCache : Scene() {
+    override suspend fun SContainer.sceneInit() {
+        setVirtualSize(Korge.DEFAULT_WINDOW_SIZE / 2)
+    }
+
     override suspend fun SContainer.sceneMain() {
         //val cached = CachedContainer().addTo(this)
         //val cached = container {  }
         val cached = cachedContainer {  }
         val random = Random(0L)
         for (n in 0 until 100_000) {
-            cached.solidRect(2, 2, random[Colors.RED, Colors.BLUE]).xy(2 * (n % 300), 2 * (n / 300))
+            cached.solidRect(1, 1, random[Colors.RED, Colors.BLUE]).xy((n % 300), (n / 300))
         }
         uiHorizontalStack {
             uiButton("Cached").clicked {
@@ -35,9 +44,37 @@ class MainCache : Scene() {
             println(cached.getChildAt(50000)._invalidateNotifier)
         }
 
+        uiHorizontalStack {
+            this.position(315, 0)
+
+            uiScrollable(size = Size(100, 100)) {
+                it.sampleTextBlock(RichTextData("Expensive Scaling: Default", font = DefaultTtfFontAsBitmap))
+            }
+
+            uiScrollable(size = Size(100, 100)) {
+                it.expensiveScaling = false
+                it.sampleTextBlock(RichTextData("Cheap Scaling: Opt-in", font = DefaultTtfFontAsBitmap))
+            }
+        }
 
         //timeout(1.seconds) {
         //    rect.color = Colors.BLUE
         //}
+    }
+
+    override suspend fun sceneAfterDestroy() {
+        super.sceneAfterDestroy()
+        setVirtualSize(Korge.DEFAULT_WINDOW_SIZE)
+    }
+
+    private fun setVirtualSize(size: Size) {
+        views.setVirtualSize(size.width.toIntCeil(), size.height.toIntCeil())
+    }
+
+    private fun Container.sampleTextBlock(richTextData: RichTextData): TextBlock {
+        return textBlock(align = TextAlignment.MIDDLE_CENTER, size = Size(100, 100)) {
+            text = richTextData
+            fill = Colors.WHITE
+        }
     }
 }

--- a/korge/src/commonMain/kotlin/korlibs/korge/view/CachedContainer.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/view/CachedContainer.kt
@@ -108,7 +108,7 @@ open class CachedContainer(
                 //ctx.ag.clear(Colors.TRANSPARENT, clearColor = true)
                 ctx.setViewMatrixTemp(globalMatrixInv
                     .translated(-lbounds.x, -lbounds.y)
-                    .scaled(windowLocalRatio)
+                    .scaled(renderScale * windowLocalRatio.scaleX, renderScale * windowLocalRatio.scaleY)
                 ) {
                     super.renderInternal(ctx)
                 }
@@ -120,7 +120,7 @@ open class CachedContainer(
                 cache.tex,
                 m = globalMatrix
                     .pretranslated(lbounds.x, lbounds.y)
-                    .prescaled(1.0 / windowLocalRatio.scaleX, 1.0 / windowLocalRatio.scaleY)
+                    .prescaled(1.0 / renderScale / windowLocalRatio.scaleX, 1.0 / renderScale / windowLocalRatio.scaleY)
                 ,
                 colorMul = renderColorMul,
                 blendMode = blendMode,

--- a/korge/src/commonMain/kotlin/korlibs/korge/view/CachedContainer.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/view/CachedContainer.kt
@@ -38,7 +38,7 @@ open class CachedContainer(
     @property:ViewProperty
     var cache: Boolean = true,
     @property:ViewProperty
-    var expensiveScaling: Boolean = true,
+    var expensiveScaling: Boolean? = null,
 ) : Container(), InvalidateNotifier {
     //@ViewProperty
     //var cache: Boolean = cache
@@ -84,16 +84,21 @@ open class CachedContainer(
         val cache = _cacheTex!!
         ctx.refGcCloseable(cache)
 
-        val renderScale: Float = when (ctx.views?.gameWindow?.quality) {
+        val renderScale: Float = when (ctx.quality) {
             GameWindow.Quality.PERFORMANCE -> 1f
             else -> ctx.devicePixelRatio
         }
         //val renderScale = 1.0
 
+        val doExpensiveScaling = expensiveScaling ?: when(ctx.quality) {
+            GameWindow.Quality.PERFORMANCE -> false
+            else -> true
+        }
+
         if (dirty || scaledCache != renderScale) {
             scaledCache = renderScale
             lbounds = getLocalBounds(includeFilters = false)
-            windowLocalRatio = if (expensiveScaling) {
+            windowLocalRatio = if (doExpensiveScaling) {
                 windowBounds.size / lbounds.size
             } else {
                 Scale(1)


### PR DESCRIPTION
Adds `CachedContainer.expensiveScaling: Boolean?`, which enables scaling of the content based on the actual window size instead of just the virtual size. Set to `true` by default. 

This fixes part of issue #1748. The default non-bitmap font is still blurry regardless of whether or not it's in a CachedContainer.

In the sandbox:

![image](https://github.com/korlibs/korge/assets/7599096/15b2610e-ce84-4b4f-9bca-6d578182dcfa)
