### PR TITLE
Fix/alsa wait

### DIFF
--- a/korau/src/commonMain/kotlin/korlibs/audio/sound/SoundAudioStream.kt
+++ b/korau/src/commonMain/kotlin/korlibs/audio/sound/SoundAudioStream.kt
@@ -88,6 +88,7 @@ class SoundAudioStream(
                         }
                     } catch (e: CancellationException) {
                         // Do nothing
+                        nas.stop()
                         params.onCancel?.invoke()
                     } finally {
                         nas.wait()

--- a/korau/src/commonMain/kotlin/korlibs/audio/sound/backends/ALSA.kt
+++ b/korau/src/commonMain/kotlin/korlibs/audio/sound/backends/ALSA.kt
@@ -148,9 +148,8 @@ class ALSAPlatformAudioOutput(
         running = false
 
         if (pcm != 0L) {
-            ASound2.snd_pcm_drain(pcm)
+            ASound2.snd_pcm_drop(pcm)
             ASound2.snd_pcm_close(pcm)
-            //println("ASound2.snd_pcm_close: ${pcm}")
             pcm = 0L
         }
     }
@@ -181,6 +180,7 @@ interface ASound2 {
     fun snd_pcm_writei(pcm: Long, buffer: ShortArray, size: Int): Int = ERROR
     fun snd_pcm_prepare(pcm: Long): Int = ERROR
     fun snd_pcm_drain(pcm: Long): Int = ERROR
+    fun snd_pcm_drop(pcm: Long): Int = ERROR
     fun snd_pcm_close(pcm: Long): Int = ERROR
 
     companion object : ASound2 by ASoundImpl {

--- a/korau/src/commonMain/kotlin/korlibs/audio/sound/backends/ALSA.kt
+++ b/korau/src/commonMain/kotlin/korlibs/audio/sound/backends/ALSA.kt
@@ -131,10 +131,15 @@ class ALSAPlatformAudioOutput(
                             buff[n * channels + ch] = (samples[ch, n] * rscale).toInt().toShort()
                         }
                     }
+                    if (!running) break
                     val result = ASound2.snd_pcm_writei(pcm, buff, frames)
                     //println("result=$result")
                     if (result == -ASound2.EPIPE) {
                         ASound2.snd_pcm_prepare(pcm)
+                    } else {
+                        while (running && ASound2.snd_pcm_delay(pcm) > frames) {
+                            blockingSleep(10.milliseconds)
+                        }
                     }
 
 
@@ -189,6 +194,7 @@ interface ASound2 {
     fun snd_pcm_prepare(pcm: Long): Int = ERROR
     fun snd_pcm_drain(pcm: Long): Int = ERROR
     fun snd_pcm_drop(pcm: Long): Int = ERROR
+    fun snd_pcm_delay(pcm: Long): Int = ERROR
     fun snd_pcm_close(pcm: Long): Int = ERROR
 
     companion object : ASound2 by ASoundImpl {

--- a/korau/src/jvmMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
+++ b/korau/src/jvmMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
@@ -47,6 +47,12 @@ actual object ASoundImpl : ASound2 {
         return tempOut.getInt(0L)
     }
 
+    override fun snd_pcm_delay(pcm: Long): Int {
+        val tempDelay = Memory(4).also { it.clear() }
+        A2.snd_pcm_delay(pcm.toCPointer(), tempDelay)
+        return tempDelay.getInt(0L)
+    }
+
     override fun snd_pcm_writei(pcm: Long, buffer: ShortArray, size: Int): Int {
         val mem = Memory((buffer.size * 2).toLong()).also { it.clear() }
         for (n in 0 until buffer.size) mem.setShort((n * 2).toLong(), buffer[n])
@@ -78,6 +84,7 @@ object A2 {
     @JvmStatic external fun snd_pcm_prepare(pcm: Pointer?): Int
     @JvmStatic external fun snd_pcm_drain(pcm: Pointer?): Int
     @JvmStatic external fun snd_pcm_drop(pcm: Pointer?): Int
+    @JvmStatic external fun snd_pcm_delay(pcm: Pointer?, delay: Pointer?): Int
     @JvmStatic external fun snd_pcm_close(pcm: Pointer?): Int
 
     init {

--- a/korau/src/jvmMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
+++ b/korau/src/jvmMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
@@ -54,6 +54,7 @@ actual object ASoundImpl : ASound2 {
     }
 
     override fun snd_pcm_prepare(pcm: Long): Int = A2.snd_pcm_prepare(pcm.toCPointer())
+    override fun snd_pcm_drop(pcm: Long): Int = A2.snd_pcm_drop(pcm.toCPointer())
     override fun snd_pcm_drain(pcm: Long): Int = A2.snd_pcm_drain(pcm.toCPointer())
     override fun snd_pcm_close(pcm: Long): Int = A2.snd_pcm_close(pcm.toCPointer())
 }
@@ -76,6 +77,7 @@ object A2 {
     @JvmStatic external fun snd_pcm_writei(pcm: Pointer?, buffer: Pointer?, size: Int): Int
     @JvmStatic external fun snd_pcm_prepare(pcm: Pointer?): Int
     @JvmStatic external fun snd_pcm_drain(pcm: Pointer?): Int
+    @JvmStatic external fun snd_pcm_drop(pcm: Pointer?): Int
     @JvmStatic external fun snd_pcm_close(pcm: Pointer?): Int
 
     init {

--- a/korau/src/nativeMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
+++ b/korau/src/nativeMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
@@ -44,6 +44,7 @@ actual object ASoundImpl : ASound2 {
 
     override fun snd_pcm_prepare(pcm: Long): Int = A2.snd_pcm_prepare(pcm.toCPointer())
     override fun snd_pcm_drain(pcm: Long): Int = A2.snd_pcm_drain(pcm.toCPointer())
+    override fun snd_pcm_drop(pcm: Long): Int = A2.snd_pcm_drop(pcm.toCPointer())
     override fun snd_pcm_close(pcm: Long): Int = A2.snd_pcm_close(pcm.toCPointer())
 }
 
@@ -67,6 +68,7 @@ internal object A2 : DynamicLibrary("libasound.so.2") {
     val snd_pcm_writei by func<(pcm: COpaquePointer?, buffer: COpaquePointer?, size: Int) -> Int>()
     val snd_pcm_prepare by func<(pcm: COpaquePointer?) -> Int>()
     val snd_pcm_drain by func<(pcm: COpaquePointer?) -> Int>()
+    val snd_pcm_drop by func<(pcm: COpaquePointer?) -> Int>()
     val snd_pcm_close by func<(pcm: COpaquePointer?) -> Int>()
 
 }

--- a/korau/src/nativeMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
+++ b/korau/src/nativeMain/kotlin/korlibs/audio/sound/backends/ALSAImpl.kt
@@ -38,6 +38,14 @@ actual object ASoundImpl : ASound2 {
         }
     }
 
+    override fun snd_pcm_delay(params: Long): Int {
+        memScoped {
+            val out = alloc<IntVar>()
+            A2.snd_pcm_delay(params.toCPointer(), out.ptr)
+            return out.value.toInt()
+        }
+    }
+
     override fun snd_pcm_writei(pcm: Long, buffer: ShortArray, size: Int): Int = buffer.usePinned {
         A2.snd_pcm_writei(pcm.toCPointer(), it.startAddressOf, size)
     }
@@ -69,6 +77,7 @@ internal object A2 : DynamicLibrary("libasound.so.2") {
     val snd_pcm_prepare by func<(pcm: COpaquePointer?) -> Int>()
     val snd_pcm_drain by func<(pcm: COpaquePointer?) -> Int>()
     val snd_pcm_drop by func<(pcm: COpaquePointer?) -> Int>()
+    val snd_pcm_delay by func<(pcm: COpaquePointer?, delay: COpaquePointer?) -> Int>()
     val snd_pcm_close by func<(pcm: COpaquePointer?) -> Int>()
 
 }


### PR DESCRIPTION
The previous commit did fix ALSA not being interruptible, but I notice that it also doesn't cleanly end on it own (i.e. without being interrupted). Specifically, `availableSamples` was not implemented, so `wait()` always returned immediately. This was not noticed, since `stop()` called `drain()` which waits for the written audio to end. This seeks to solve that by:

- properly updating `availableSamples` so `wait()` works properly
- change `stop()` to call `snd_pcm_drop()` instead of `snd_pcm_drain()` to immediately drop all remaining frames, instead of waiting for them to finish
- calling `wait()` then `stop()` when a sound is done
- calling only `stop()` when a sound is cancelled
- implement `snd_pcm_delay()` to get the number of `frames` remaining to be heard after `snd_pcm_writei` to determine how long to wait before writing the next sound (or returning, if done). 