### PR TITLE
Fixes .ase slice name generation, to not repeat names that are already used, also cover the case where a nameToVariable generated the same name

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/typedresources/TypedResourcesGenerator.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/typedresources/TypedResourcesGenerator.kt
@@ -166,11 +166,15 @@ class TypedResourcesGenerator {
                             line("val animations: TypedAnimation.Companion get() = TypedAnimation")
                         }
 
+                        val uniqueNames = UniqueNameGenerator()
+                        uniqueNames["animations"] // reserve names
+                        uniqueNames["default"] // reserve names
+
                         line("val animations: TypedAnimation.Companion get() = TypedAnimation")
                         line("val default: TypedImageData get() = TypedImageData(data.default)")
-                        for (slice in info.slices) {
-                            val varName = slice.sliceName.nameToVariable()
-                            line("val `$varName`: TypedImageData get() = TypedImageData(data[${slice.sliceName.quoted}]!!)")
+                        for (sliceName in info.slices.map { it.sliceName }.distinct()) {
+                            val varName = uniqueNames[sliceName.nameToVariable()]
+                            line("val `$varName`: TypedImageData get() = TypedImageData(data[${sliceName.quoted}]!!)")
                         }
                         // @TODO: We could
 

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/UniqueNameGenerator.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/UniqueNameGenerator.kt
@@ -1,0 +1,16 @@
+package korlibs.korge.gradle.util
+
+class UniqueNameGenerator {
+    val nameToSuffix = LinkedHashMap<String, Int>()
+
+    operator fun get(name: String): String {
+        if (name !in nameToSuffix) {
+            nameToSuffix[name] = -1
+            return name
+        } else {
+            val index = nameToSuffix[name]!! + 1
+            nameToSuffix[name] = index
+            return get("$name$index")
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/korlibs/korge/gradle/util/UniqueNameGeneratorTest.kt
+++ b/buildSrc/src/test/kotlin/korlibs/korge/gradle/util/UniqueNameGeneratorTest.kt
@@ -1,0 +1,19 @@
+package korlibs.korge.gradle.util
+
+import org.junit.*
+
+class UniqueNameGeneratorTest {
+    @Test
+    fun test() {
+        val names = UniqueNameGenerator()
+        Assert.assertEquals("hello", names.get("hello"))
+        Assert.assertEquals("hello0", names.get("hello"))
+        Assert.assertEquals("hello1", names.get("hello"))
+        Assert.assertEquals("hello00", names.get("hello0"))
+        Assert.assertEquals("hello01", names.get("hello0"))
+        Assert.assertEquals("hello10", names.get("hello1"))
+        Assert.assertEquals("hello11", names.get("hello1"))
+        Assert.assertEquals("hello110", names.get("hello11"))
+        Assert.assertEquals("hello2", names.get("hello"))
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/korlibs/korge/issues/1779