### PR TITLE
Inverts preventDefault <-> stopPropagation behaviour to match JS. Supports dispatching events down and up or both. This will allow to fix the keyboard, touch and mouse events to go from down to up (bubbling)

### DIFF
--- a/korge/src/commonMain/kotlin/korlibs/korge/input/MouseEvents.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/input/MouseEvents.kt
@@ -398,7 +398,7 @@ class MouseEvents(val view: View) : Extra by Extra.Mixin(), Closeable {
                     if (isOver) {
                         click(this@MouseEvents)
                         if (click.listenerCount > 0) {
-                            preventDefault(view)
+                            event.stopPropagation(view)
                         }
                     }
                 }

--- a/korge/src/commonMain/kotlin/korlibs/korge/view/Container.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/view/Container.kt
@@ -475,7 +475,7 @@ open class Container(
     override fun <T : BEvent> dispatchChildren(type: EventType<T>, event: T, result: EventResult?) {
         if (__tempDispatchChildren == null) __tempDispatchChildren = FastArrayList(children.size)
         __children.fastForEachWithTemp(__tempDispatchChildren!!) {
-            it.dispatch(type, event, result)
+            it.dispatchDown(type, event, result)
         }
     }
 }

--- a/korge/src/commonMain/kotlin/korlibs/korge/view/View.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/view/View.kt
@@ -1376,6 +1376,10 @@ abstract class View internal constructor(
         view.parent?.globalMatrix?.let { out *= it }
         return out
     }
+
+    override fun <T : BEvent> dispatchParent(type: EventType<T>, event: T, result: EventResult?) {
+        parent?.dispatchUp(type, event, result)
+    }
 }
 
 // Doesn't seem to work

--- a/korge/src/commonMain/kotlin/korlibs/korge/view/Views.kt
+++ b/korge/src/commonMain/kotlin/korlibs/korge/view/Views.kt
@@ -240,8 +240,15 @@ class Views(
 		resized()
 	}
 
-    override fun <T : BEvent> dispatch(event: T) {
-        super.dispatch(event)
+    override fun <T : BEvent> dispatch(
+        type: EventType<T>,
+        event: T,
+        result: EventResult?,
+        up: Boolean,
+        down: Boolean
+    ): Boolean {
+        event.defaultPrevented = false
+        val result = super.dispatch(type, event, result, up, down)
         val e = event
         e.target = views
         // @TODO: Remove this
@@ -255,10 +262,11 @@ class Views(
             }
         }
         try {
-            stage.dispatch(e)
-        } catch (e: PreventDefaultException) {
+            return stage.dispatch(e)
+        } catch (e: StopPropagatingException) {
             //println("PreventDefaultException.Reason: ${e.reason}")
         }
+        return result
     }
 
 	fun render() {

--- a/korge/src/commonTest/kotlin/korlibs/korge/view/ViewTest.kt
+++ b/korge/src/commonTest/kotlin/korlibs/korge/view/ViewTest.kt
@@ -1,6 +1,7 @@
 package korlibs.korge.view
 
 import assertEqualsFloat
+import korlibs.event.*
 import korlibs.image.bitmap.*
 import korlibs.io.lang.*
 import korlibs.korge.tests.*
@@ -304,5 +305,23 @@ class ViewTest {
             assertFailsWith<InvalidOperationException> { container3.addChild(container1) }.message
         )
         assertNull(container1.parent)
+    }
+
+    @Test
+    fun testEventBubbles() {
+        val log = arrayListOf<String>()
+        val container = Container()
+        val child1 = container.container()
+        val child2 = child1.container()
+        container.onEvent(MyEvent) { log += "container" }
+        child1.onEvent(MyEvent) { log += "child1" }
+        child2.onEvent(MyEvent) { log += "child2" }
+        child2.dispatch(MyEvent())
+        assertEquals("child2,child1,container", log.joinToString(","))
+    }
+
+    class MyEvent : Event(), TEvent<MyEvent> {
+        override val type: EventType<MyEvent> = MyEvent
+        companion object : EventType<MyEvent>
     }
 }

--- a/korgw/src/commonMain/kotlin/korlibs/event/Events.kt
+++ b/korgw/src/commonMain/kotlin/korlibs/event/Events.kt
@@ -10,22 +10,32 @@ import korlibs.math.geom.*
 
 open class TypedEvent<T : BEvent>(open override var type: EventType<T>) : Event(), TEvent<T>
 
-open class Event {
+// @TODO: No override required!
+//open class Demo { var a: Int = 10 }
+//interface BDemo { val a: Int }
+//interface TBDemo<T : BDemo> : BDemo {}
+//class Test : Demo(), TBDemo<Test> {}
+
+abstract class Event {
     var target: Any? = null
-    var _stopPropagation = false
-    fun stopPropagation() {
-        _stopPropagation = true
+    fun stopPropagation(reason: Any? = null) {
+        throw StopPropagatingException(reason)
+    }
+    var defaultPrevented: Boolean = false
+    fun preventDefault(reason: Any? = null) {
+        defaultPrevented = true
     }
 }
 
-fun Event.preventDefault(reason: Any? = null): Nothing = throw PreventDefaultException(reason)
-fun preventDefault(reason: Any? = null): Nothing = throw PreventDefaultException(reason)
-
-class PreventDefaultException(val reason: Any? = null) : Exception()
+@Deprecated("") fun Event.preventDefault(reason: Any? = null): Nothing = throw PreventDefaultException(reason)
+@Deprecated("") fun preventDefault(reason: Any? = null): Nothing = throw PreventDefaultException(reason)
+@Deprecated("") class PreventDefaultException(val reason: Any? = null) : Exception()
+class StopPropagatingException(val reason: Any? = null) : Exception()
 
 interface BEvent {
     var target: Any?
     val type: EventType<out BEvent>
+    var defaultPrevented: Boolean
 }
 
 interface TEvent<T : BEvent> : BEvent {

--- a/korgw/src/commonMain/kotlin/korlibs/render/GameWindow.kt
+++ b/korgw/src/commonMain/kotlin/korlibs/render/GameWindow.kt
@@ -392,7 +392,7 @@ open class GameWindow :
     protected val dropFileEvent = DropFileEvent()
 
     inline fun <T : Event> T.reset(block: T.() -> Unit = {}): T {
-        this._stopPropagation = false
+        this.defaultPrevented = false
         block(this)
         return this
     }
@@ -768,7 +768,7 @@ open class GameWindow :
                 this.str = str
             }
         })
-        return keyEvent._stopPropagation
+        return keyEvent.defaultPrevented
     }
 
     fun dispatchSimpleMouseEvent(
@@ -788,7 +788,6 @@ open class GameWindow :
             this.mouseButtons = this.mouseButtons.setBits(if (button != null) 1 shl button.ordinal else 0, type == MouseEvent.Type.DOWN)
         }
         dispatch(mouseEvent.reset {
-            this._stopPropagation = false
             this.type = type
             this.id = id
             this.x = x

--- a/korgw/src/commonTest/kotlin/korlibs/event/EventListenerTest.kt
+++ b/korgw/src/commonTest/kotlin/korlibs/event/EventListenerTest.kt
@@ -23,7 +23,7 @@ class EventListenerTest {
 
         override fun <T : BEvent> dispatchChildren(type: EventType<T>, event: T, result: EventResult?) {
             for (child in children) {
-                child.dispatch(type, event, result)
+                child.dispatchDown(type, event, result)
             }
         }
     }


### PR DESCRIPTION
Some work on https://github.com/korlibs/korge/issues/439#issuecomment-1627435632
