### PR TITLE
Make libs.asm.util be available only on tests

### DIFF
--- a/korge-core/build.gradle.kts
+++ b/korge-core/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     //add("commonTestApi", project(":korge-test"))
     add("commonTestApi", libs.kotlinx.coroutines.test)
     add("jvmMainApi", libs.asm.core)
-    add("jvmMainApi", libs.asm.util)
+    add("jvmTestApi", libs.asm.util)
 }
 
 korlibs.NativeTools.configureAndroidDependency(project, libs.kotlinx.coroutines.android)

--- a/korge-core/test/jvm/korlibs/wasm/WasmJVMTest.kt
+++ b/korge-core/test/jvm/korlibs/wasm/WasmJVMTest.kt
@@ -198,7 +198,7 @@ open class WasmTest {
 
     protected suspend fun createModuleRuntimeJVM(file: String, loadTrace: Boolean = false, memPages: Int = 10, codeTrace: Boolean = false, validate: Boolean = true): WasmRuntime {
         val reader = WasmReaderBinary().also { it.doTrace = loadTrace }.read(resourcesVfs[file].readBytes().openSync())
-        val wasmModule = WasmRunJVMOutput().also { it.trace = codeTrace; it.validate = validate }.generate(reader.toModule())
+        val wasmModule = WasmRunJVMOutputExt().also { it.trace = codeTrace; it.validate = validate }.generate(reader.toModule())
         return wasmModule
     }
 

--- a/korge-core/test/jvm/korlibs/wasm/WasmRunJVMJITExt.kt
+++ b/korge-core/test/jvm/korlibs/wasm/WasmRunJVMJITExt.kt
@@ -1,0 +1,27 @@
+package korlibs.wasm
+
+import org.objectweb.asm.*
+import org.objectweb.asm.util.*
+import java.io.*
+
+class WasmRunJVMOutputExt(OUTPUT_CLASS_NAME: String = "WasmProgram") : WasmRunJVMOutput(OUTPUT_CLASS_NAME) {
+    override fun getClassVisitor(cw: ClassWriter, doValidate: Boolean): ClassVisitor {
+        return if (doValidate) CheckClassAdapter(cw) else cw
+    }
+
+    override fun dumpJVMBytecode(bytes: ByteArray) {
+        ClassReader(bytes).accept(TraceClassVisitor(null, ASMifier(), PrintWriter(System.out)), 0)
+    }
+
+    override fun useMethodVisitor(myMethod: MethodVisitor, doTrace: Boolean, block: (mv: MethodVisitor) -> Unit) {
+        val asmifier = ASMifier()
+        val mv: MethodVisitor = if (doTrace) TraceMethodVisitor(myMethod, asmifier) else myMethod
+        block(mv)
+        if (doTrace) println(asmifier.text.joinToString(""))
+    }
+
+    companion object {
+        fun build(module: WasmModule, codeTrace: Boolean = false): WasmRunJVMJIT =
+            WasmRunJVMJIT.build(module, outputGen = { WasmRunJVMOutputExt() }, codeTrace)
+    }
+}

--- a/korge-core/test/jvm/korlibs/wasm/WastReaderTest.kt
+++ b/korge-core/test/jvm/korlibs/wasm/WastReaderTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 
 class WastReaderTestJit : WastReaderTest() {
     override fun runModule(module: WasmModule, codeTrace: Boolean) {
-        WasmRunJVMJIT.build(module, codeTrace = codeTrace).invoke("run\$asserts")
+        WasmRunJVMOutputExt.build(module, codeTrace = codeTrace).invoke("run\$asserts")
     }
 }
 


### PR DESCRIPTION
Since it shouldn't be required for production, only to improve debugging