### PR TITLE
Add and support preferSyncIo in tests & KorGE

### DIFF
--- a/korge-core/src/common/korlibs/io/async/PreferSyncIo.kt
+++ b/korge-core/src/common/korlibs/io/async/PreferSyncIo.kt
@@ -1,0 +1,14 @@
+package korlibs.io.async
+
+import kotlin.coroutines.*
+
+val CoroutineContext.preferSyncIo: Boolean get() = this[PreferSyncIo]?.preferSyncIo == true
+
+data class PreferSyncIo(val preferSyncIo: Boolean) : CoroutineContext.Element {
+    override val key get() = PreferSyncIo
+    companion object : CoroutineContext.Key<PreferSyncIo> {
+        operator fun invoke(preferSyncIo: Boolean?): PreferSyncIo = if (preferSyncIo == true) SYNC else ASYNC
+        val SYNC = PreferSyncIo(preferSyncIo = true)
+        val ASYNC = PreferSyncIo(preferSyncIo = false)
+    }
+}

--- a/korge-core/src/jvmAndroid/korlibs/io/file/std/AsynchronousFileChannelVfs.kt
+++ b/korge-core/src/jvmAndroid/korlibs/io/file/std/AsynchronousFileChannelVfs.kt
@@ -1,16 +1,16 @@
 package korlibs.io.file.std
 
-import korlibs.io.file.VfsOpenMode
-import korlibs.io.stream.AsyncStream
-import korlibs.io.stream.AsyncStreamBase
-import korlibs.io.stream.toAsyncStream
+import korlibs.io.async.*
+import korlibs.io.file.*
+import korlibs.io.stream.*
 import korlibs.io.util.nioSuspendCompletion
-import java.io.FileNotFoundException
-import java.nio.ByteBuffer
-import java.nio.channels.AsynchronousFileChannel
-import java.nio.file.OpenOption
-import java.nio.file.StandardOpenOption
-import kotlin.io.path.Path
+import java.io.*
+import java.nio.*
+import java.nio.channels.*
+import java.nio.file.*
+import kotlin.collections.buildList
+import kotlin.coroutines.*
+import kotlin.io.path.*
 
 // Requires JVM 7, and Android API Level 26 (Android Oreo 8.0)
 internal open class AsynchronousFileChannelVfs : BaseLocalVfsJvm() {
@@ -28,6 +28,8 @@ internal open class AsynchronousFileChannelVfs : BaseLocalVfsJvm() {
 
     @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun open(path: String, mode: VfsOpenMode): AsyncStream {
+        if (coroutineContext.preferSyncIo) return super.open(path, mode)
+
         val raf = openAsynchronousFileChannel(path, mode)
         return object : AsyncStreamBase() {
             override suspend fun read(position: Long, buffer: ByteArray, offset: Int, len: Int): Int =

--- a/korge-core/test/common/korlibs/io/file/std/PreferSyncIoTest.kt
+++ b/korge-core/test/common/korlibs/io/file/std/PreferSyncIoTest.kt
@@ -1,0 +1,22 @@
+package korlibs.io.file.std
+
+import korlibs.platform.*
+import kotlin.test.*
+
+class PreferSyncIoTest {
+    @Test
+    fun testSyncIO() = korlibs.io.async.suspendTest({ Platform.isJvm }, preferSyncIo = true) {
+        val exception = assertFails { resourcesVfs["unexistant.unk"].readBytes() }
+        assertTrue("All stack entries available because executed synchronously") {
+            "korlibs.io.file.std.BaseLocalVfsJvm" in exception.stackTraceToString()
+        }
+    }
+
+    @Test
+    fun testAsyncIO() = korlibs.io.async.suspendTest({ Platform.isJvm }, preferSyncIo = false) {
+        val exception = assertFails { resourcesVfs["unexistant.unk"].readBytes() }
+        assertTrue("Some stack entries lost in the async stacktrace") {
+            "korlibs.io.file.std.BaseLocalVfsJvm" !in exception.stackTraceToString()
+        }
+    }
+}

--- a/korge/src/common/korlibs/korge/Korge.kt
+++ b/korge/src/common/korlibs/korge/Korge.kt
@@ -8,6 +8,7 @@ import korlibs.graphics.log.*
 import korlibs.image.color.*
 import korlibs.image.format.*
 import korlibs.inject.*
+import korlibs.io.*
 import korlibs.io.async.*
 import korlibs.io.dynamic.*
 import korlibs.io.file.std.*
@@ -86,6 +87,8 @@ suspend fun Korge(
     debugFontColor: RGBA = Colors.WHITE,
     stageBuilder: (Views) -> Stage = { Stage(it) },
     targetFps: Double = 0.0,
+    /** false by default, useful only for debugging on the JVM */
+    preferSyncIo: Boolean? = null,
     entry: suspend Stage.() -> Unit = {}
 ): Unit = Korge(
     args = args, imageFormats = imageFormats, gameWindow = gameWindow, mainSceneClass = mainSceneClass,
@@ -104,6 +107,7 @@ suspend fun Korge(
     stageBuilder = stageBuilder,
     unit = Unit,
     targetFps = targetFps,
+    preferSyncIo = preferSyncIo,
 ).start(entry)
 
 data class Korge(
@@ -141,6 +145,7 @@ data class Korge(
     val debugFontColor: RGBA = Colors.WHITE,
     val stageBuilder: (Views) -> Stage = { Stage(it) },
     val targetFps: Double = 0.0,
+    val preferSyncIo: Boolean? = null,
     val unit: Unit = Unit,
 ) {
     companion object {
@@ -150,7 +155,9 @@ data class Korge(
     }
 
     suspend fun start(entry: suspend Stage.() -> Unit = this.main) {
-        KorgeRunner.invoke(this.copy(main = entry))
+        withContext(PreferSyncIo(preferSyncIo)) {
+            KorgeRunner.invoke(this@Korge.copy(main = entry))
+        }
     }
 }
 


### PR DESCRIPTION
Useful for testing and debugging without losing stack traces without enabling async stacktraces when doing I/O