### PR TITLE
Fix UIButton background color not updating properly

### DIFF
--- a/korge/src/common/korlibs/korge/ui/UIButton.kt
+++ b/korge/src/common/korlibs/korge/ui/UIButton.kt
@@ -102,8 +102,10 @@ open class UIButton(
     override var enabled: Boolean
         get() = super.enabled
         set(value) {
+            if (value != mouseEnabled)
+                updatedUIButton(enabled = value)
+
             mouseEnabled = value
-            updatedUIButton(enabled = value)
         }
 
     //protected val rect: NinePatchEx = ninePatch(null, width, height)

--- a/korge/src/common/korlibs/korge/ui/UIButton.kt
+++ b/korge/src/common/korlibs/korge/ui/UIButton.kt
@@ -99,6 +99,13 @@ open class UIButton(
             setInitialState()
         }
 
+    override var enabled: Boolean
+        get() = super.enabled
+        set(value) {
+            mouseEnabled = value
+            updatedUIButton(enabled = value)
+        }
+
     //protected val rect: NinePatchEx = ninePatch(null, width, height)
     //protected val background = roundRect(
     //    width, height, radiusWidth(width), radiusHeight(height), bgColorOut)
@@ -256,10 +263,10 @@ open class UIButton(
         touch.simulateTapAt(views, localToGlobal(Point(width * 0.5f, height * 0.5f)))
     }
 
-    open fun updatedUIButton(down: Boolean? = null, over: Boolean? = null, pos: Point = Point.ZERO, immediate: Boolean = false) {
+    open fun updatedUIButton(down: Boolean? = null, over: Boolean? = null, enabled: Boolean? = null, pos: Point = Point.ZERO, immediate: Boolean = false) {
         val bgColor = when {
-            !enabled -> bgColorDisabled
-            over ?: false -> bgColorOver
+            enabled == false -> bgColorDisabled
+            over == true -> bgColorOver
             selected -> bgColorSelected
             else -> bgColorOut
         }

--- a/korge/src/common/korlibs/korge/ui/UIButton.kt
+++ b/korge/src/common/korlibs/korge/ui/UIButton.kt
@@ -257,59 +257,23 @@ open class UIButton(
     }
 
     open fun updatedUIButton(down: Boolean? = null, over: Boolean? = null, pos: Point = Point.ZERO, immediate: Boolean = false) {
-        val button = this
-        if (!button.enabled) {
-            //button.animStateManager.set(
-            //    AnimState(
-            //        button::bgcolor[button.bgColorDisabled]
-            //))
-            //button.animatorEffects.cancel()
-            background.bgColor = button.bgColorDisabled
-            button.invalidateRender()
-            return
+        val bgColor = when {
+            !enabled -> bgColorDisabled
+            over ?: false -> bgColorOver
+            selected -> bgColorSelected
+            else -> bgColorOut
         }
-        //println("UPDATED: down=$down, over=$over, px=$px, py=$py")
+
+        if (immediate) {
+            background.bgColor = bgColor
+        } else {
+            animator.tween(background::bgColor[bgColor], time = 0.25.seconds)
+        }
+
         if (down == true) {
-            //button.animStateManager.set(
-            //    AnimState(
-            //        button::highlightRadius[0.0, 1.0],
-            //        button::highlightAlpha[1.0],
-            //        button::highlightPos[Point(px / button.width, py / button.height), Point(px / button.width, py / button.height)],
-            //    ))
             background.addHighlight(pos)
-                /*
-            button.highlightPos.setTo(px / button.width, py / button.height)
-            button.animatorEffects.tween(
-                button::highlightRadius[0.0, 1.0],
-                button::highlightColor[Colors.WHITE.withAd(0.5), Colors.WHITE.withAd(0.5)],
-                time = 0.5.seconds, easing = Easing.EASE_IN
-            )
-            */
-        }
-        if (down == false) {
-            //button.animStateManager.set(
-            //    AnimState(button::highlightAlpha[0.0])
-            //)
+        } else {
             background.removeHighlights()
-            //button.animatorEffects.tween(button::highlightColor[Colors.TRANSPARENT_BLACK], time = 0.2.seconds)
-        }
-        if (over != null) {
-            val bgcolor = when {
-                !button.enabled -> button.bgColorDisabled
-                over -> button.bgColorOver
-                selected -> button.bgColorSelected
-                else -> button.bgColorOut
-            }
-            //button.animStateManager.set(
-            //    AnimState(
-            //        button::bgcolor[bgcolor]
-            //    )
-            //)
-            if (immediate) {
-                background.bgColor = bgcolor
-            } else {
-                button.animator.tween(background::bgColor[bgcolor], time = 0.25.seconds)
-            }
         }
     }
 

--- a/korge/src/common/korlibs/korge/ui/UIButton.kt
+++ b/korge/src/common/korlibs/korge/ui/UIButton.kt
@@ -102,11 +102,10 @@ open class UIButton(
     override var enabled: Boolean
         get() = super.enabled
         set(value) {
-            val valueChanged = value != mouseEnabled
-            mouseEnabled = value
+            if (value == mouseEnabled) return
 
-            if (valueChanged)
-                updatedUIButton(enable = value)
+            mouseEnabled = value
+            updatedUIButton(enable = value)
         }
 
     //protected val rect: NinePatchEx = ninePatch(null, width, height)

--- a/korge/src/common/korlibs/korge/ui/UIButton.kt
+++ b/korge/src/common/korlibs/korge/ui/UIButton.kt
@@ -102,10 +102,11 @@ open class UIButton(
     override var enabled: Boolean
         get() = super.enabled
         set(value) {
-            if (value != mouseEnabled)
-                updatedUIButton(enabled = value)
-
+            val valueChanged = value != mouseEnabled
             mouseEnabled = value
+
+            if (valueChanged)
+                updatedUIButton(enable = value)
         }
 
     //protected val rect: NinePatchEx = ninePatch(null, width, height)
@@ -265,9 +266,17 @@ open class UIButton(
         touch.simulateTapAt(views, localToGlobal(Point(width * 0.5f, height * 0.5f)))
     }
 
-    open fun updatedUIButton(down: Boolean? = null, over: Boolean? = null, enabled: Boolean? = null, pos: Point = Point.ZERO, immediate: Boolean = false) {
+    open fun updatedUIButton(down: Boolean? = null, over: Boolean? = null, enable: Boolean? = null, pos: Point = Point.ZERO, immediate: Boolean = false) {
+        if (enabled && down != null) {
+            if (down) {
+                background.addHighlight(pos)
+            } else {
+                background.removeHighlights()
+            }
+        }
+
         val bgColor = when {
-            enabled == false -> bgColorDisabled
+            enable == false || !enabled -> bgColorDisabled
             over == true -> bgColorOver
             selected -> bgColorSelected
             else -> bgColorOut
@@ -277,12 +286,6 @@ open class UIButton(
             background.bgColor = bgColor
         } else {
             animator.tween(background::bgColor[bgColor], time = 0.25.seconds)
-        }
-
-        if (down == true) {
-            background.addHighlight(pos)
-        } else if (down == false) {
-            background.removeHighlights()
         }
     }
 

--- a/korge/src/common/korlibs/korge/ui/UIButton.kt
+++ b/korge/src/common/korlibs/korge/ui/UIButton.kt
@@ -279,7 +279,7 @@ open class UIButton(
 
         if (down == true) {
             background.addHighlight(pos)
-        } else {
+        } else if (down == false) {
             background.removeHighlights()
         }
     }


### PR DESCRIPTION
This fixes the following bug:
- The UIButton's background color doesn't update when setting `enabled` from `false` to `true` (enabling from disabled state)

**Implementation:**
- Improved and slimmed down `UIButton.updatedUIButton`