### PR TITLE
Fix ViewStyles not passing down to children

### DIFF
--- a/korge/src/common/korlibs/korge/style/ViewStyles.kt
+++ b/korge/src/common/korlibs/korge/style/ViewStyles.kt
@@ -5,7 +5,6 @@ import korlibs.image.color.*
 import korlibs.image.font.*
 import korlibs.image.text.*
 import korlibs.io.concurrent.atomic.*
-import korlibs.korge.ui.*
 import korlibs.korge.view.*
 import kotlin.reflect.*
 
@@ -28,7 +27,7 @@ class ViewStyles(val view: View) {
     var updating = KorAtomicInt(0)
 
     fun <T> getProp(prop: KProperty<T>, default: T): T =
-        (data?.get(prop.name) as? T?) ?: (view.parent as? UIView)?.styles?.getProp(prop, default) ?: default
+        (data?.get(prop.name) as? T?) ?: view.parent?.styles?.getProp(prop, default) ?: default
 
     fun doUpdate(updating: Int = this.updating.value) {
         if (updating == 0) {


### PR DESCRIPTION
- Fixes `ViewStyles` not being passed down to children.

#### Explanation
This Bug occurs when the parent is not an `UIView`.
One example is `SContainer`, which is only a `View` and not a `UIView`, meaning the `styles` of an `SContainer` will never pass down to their children.
Meaning you can never define one global style within your apps entrypoint.