### PR TITLE
Re-enable K/N desktop for korlibs-time and try to test using github action matrix

### DIFF
--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -239,7 +239,7 @@ jobs:
           - { os: windows-latest, outputKey: testWindows, testTask: mingwX64Test }
           - { os: ubuntu-latest, outputKey: testLinux, testTask: linuxX64Test, buildTasks: publishLinuxArm64PublicationToMavenLocal }
           - { os: macos-11, outputKey: testMacos, testTask: macosX64Test, buildTasks: publishMacosArm64PublicationToMavenLocal }
-    if: ${{ needs.changes.outputs[matrix.outputKey] == 'true' }}
+    #if: ${{ needs.changes.outputs[matrix.outputKey] == 'true' }}
     timeout-minutes: 240
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -230,3 +230,27 @@ jobs:
       - { name: Run ios simulator tests, run: ./gradlew iosX64Test }
       #- { name: Check compilation of tvOS targets, run: ./gradlew publishTvosArm64PublicationToMavenLocal }
       - { name: Archive Test Results, if: failure(), uses: actions/upload-artifact@v3, with: { name: screenshot-test-results-macos, retention-days: 21, path: "**/build/reports", if-no-files-found: ignore } }
+
+  test-native:
+    needs: changes
+    strategy:
+      matrix:
+        include:
+          - { os: windows-latest, outputKey: testWindows, testTask: mingwX64Test }
+          - { os: ubuntu-latest, outputKey: testLinux, testTask: linuxX64Test, buildTasks: publishLinuxArm64PublicationToMavenLocal }
+          - { os: macos-11, outputKey: testMacos, testTask: macosX64Test, buildTasks: publishMacosArm64PublicationToMavenLocal }
+    if: ${{ needs.changes.outputs[matrix.outputKey] == 'true' }}
+    timeout-minutes: 240
+    runs-on: ${{ matrix.os }}
+    env:
+      DISABLE_ANDROID: true
+      DISABLE_SANDBOX: true
+    steps:
+      - { uses: actions/checkout@v3 }
+      - { name: Replace gradle wrapper, run: "sed 's/-all/-bin/g' gradle/wrapper/gradle-wrapper.properties > gradle/wrapper/gradle-wrapper.properties.bak; cp gradle/wrapper/gradle-wrapper.properties.bak gradle/wrapper/gradle-wrapper.properties" }
+      - { name: Set up JDK, uses: actions/setup-java@v3, with: { distribution: "${{ env.JAVA_DISTRIBUTION }}", java-version: "${{ env.JAVA_VERSION }}" } }
+      - { name: Prepare Gradle, uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc } # v2.8.0
+      - { name: Start gradle, run: ./gradlew }
+      - { name: Run ${{ matrix.testTask }} tests, run: ./gradlew ${{ matrix.testTask }} }
+      - { if: ${{ matrix.buildTasks }}, name: Run ${{ matrix.buildTasks }}, run: ./gradlew ${{ matrix.buildTasks }} }
+      - { name: Archive Test Results, if: failure(), uses: actions/upload-artifact@v3, with: { name: test-results-${{ matrix.os }}, retention-days: 21, path: "**/build/reports", if-no-files-found: ignore } }

--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -251,6 +251,6 @@ jobs:
       - { name: Set up JDK, uses: actions/setup-java@v3, with: { distribution: "${{ env.JAVA_DISTRIBUTION }}", java-version: "${{ env.JAVA_VERSION }}" } }
       - { name: Prepare Gradle, uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc } # v2.8.0
       - { name: Start gradle, run: ./gradlew }
-      - { name: Run ${{ matrix.testTask }} tests, run: ./gradlew ${{ matrix.testTask }} }
-      - { if: ${{ matrix.buildTasks }}, name: Run ${{ matrix.buildTasks }}, run: ./gradlew ${{ matrix.buildTasks }} }
-      - { name: Archive Test Results, if: failure(), uses: actions/upload-artifact@v3, with: { name: test-results-${{ matrix.os }}, retention-days: 21, path: "**/build/reports", if-no-files-found: ignore } }
+      - { name: "Run ${{ matrix.testTask }} tests", run: "./gradlew ${{ matrix.testTask }}" }
+      - { name: "Run ${{ matrix.buildTasks }}", if: "${{ matrix.buildTasks }}", run: "./gradlew ${{ matrix.buildTasks }}" }
+      - { name: Archive Test Results, if: failure(), uses: actions/upload-artifact@v3, with: { name: "test-results-${{ matrix.os }}", retention-days: 21, path: "**/build/reports", if-no-files-found: ignore } }

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/Targets.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/Targets.kt
@@ -23,6 +23,9 @@ val inCI: Boolean get() = !System.getenv("CI").isNullOrBlank() || !System.getPro
 
 val KotlinTarget.isIos get() = name.startsWith("ios")
 val KotlinTarget.isTvos get() = name.startsWith("tvos")
+val KotlinTarget.isLinux get() = name.startsWith("linux")
+val KotlinTarget.isMingw get() = name.startsWith("mingw")
+val KotlinTarget.isMacos get() = name.startsWith("macos")
 
 fun NamedDomainObjectContainer<KotlinSourceSet>.createPairSourceSet(
     name: String,

--- a/buildSrc/src/main/kotlin/korlibs/modules/Targets.kt
+++ b/buildSrc/src/main/kotlin/korlibs/modules/Targets.kt
@@ -2,6 +2,7 @@ package korlibs.modules
 
 import org.gradle.api.*
 import korlibs.korge.gradle.targets.*
+import korlibs.korge.gradle.targets.desktop.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 
 
@@ -10,6 +11,16 @@ val Project.doEnableKotlinMobile: Boolean get() = supportKotlinNative && rootPro
 val Project.doEnableKotlinMobileTvos: Boolean get() = doEnableKotlinMobile && rootProject.findProperty("enableKotlinMobileTvos") == "true"
 
 val Project.hasAndroid get() = extensions.findByName("android") != null
+
+fun org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithPresetFunctions.desktopTargets(project: Project): List<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+    if (!supportKotlinNative) return listOf()
+
+    val out = arrayListOf<KotlinNativeTarget>()
+    out.addAll(listOf(linuxX64(), linuxArm64()))
+    out.addAll(listOf(mingwX64()))
+    out.addAll(listOf(macosX64(), macosArm64()))
+    return out
+}
 
 fun org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithPresetFunctions.mobileTargets(project: Project): List<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
     if (!project.doEnableKotlinMobile) return listOf()

--- a/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
+++ b/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.api.file.*
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.testing.*
 import org.jetbrains.dokka.gradle.*
+import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.targets.js.npm.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.*
@@ -444,17 +445,29 @@ object RootKorlibsPlugin {
                             //val iosTvosMacos by lazy { createPairSourceSet("iosTvosMacos", darwin) }
                             //val iosMacos by lazy { createPairSourceSet("iosMacos", iosTvosMacos) }
 
-                            //val linux by lazy { createPairSourceSet("linux", posix) }
-                            //val macos by lazy { createPairSourceSet("macos", iosMacos) }
-                            //val mingw by lazy { createPairSourceSet("mingw", native) }
-
                             val native by lazy { createPairSourceSet("native", concurrent, project = project) }
                             val posix by lazy { createPairSourceSet("posix", native, project = project) }
-                            val darwin by lazy { createPairSourceSet("darwin", posix, project = project) }
+                            val apple by lazy { createPairSourceSet("apple", posix, project = project) }
+                            val darwin by lazy { createPairSourceSet("darwin", apple, project = project) }
                             val darwinMobile by lazy { createPairSourceSet("darwinMobile", darwin, project = project) }
                             val iosTvos by lazy { createPairSourceSet("iosTvos", darwinMobile/*, iosTvosMacos*/, project = project) }
                             val tvos by lazy { createPairSourceSet("tvos", iosTvos, project = project) }
                             val ios by lazy { createPairSourceSet("ios", iosTvos/*, iosMacos*/, project = project) }
+
+                            if (project.name == "korlibs-time") {
+                                val macos by lazy { createPairSourceSet("macos", darwin, project = project) }
+                                val linux by lazy { createPairSourceSet("linux", posix, project = project) }
+                                val mingw by lazy { createPairSourceSet("mingw", native, project = project) }
+
+                                for (target in desktopTargets(project)) {
+                                    val native = createPairSourceSet(target.name, project = project)
+                                    when {
+                                        target.isLinux -> native.dependsOn(linux)
+                                        target.isMacos -> native.dependsOn(macos)
+                                        target.isMingw -> native.dependsOn(mingw)
+                                    }
+                                }
+                            }
 
                             for (target in mobileTargets(project)) {
                                 val native = createPairSourceSet(target.name, project = project)

--- a/buildSrc/src/main/kotlin/korlibs/tools.kt
+++ b/buildSrc/src/main/kotlin/korlibs/tools.kt
@@ -28,6 +28,10 @@ fun MutableMap<String, Any>.applyProjectProperties(
     put("project.author.email", "soywiz@gmail.com")
 }
 
+fun MutableMap<String, Any>.includeKotlinNativeDesktop() {
+    this["include.kotlin.native.desktop"] = true
+}
+
 // Extensions
 operator fun File.get(name: String) = File(this, name)
 

--- a/korlibs-time/build.gradle.kts
+++ b/korlibs-time/build.gradle.kts
@@ -3,6 +3,8 @@ import korlibs.*
 description = "Korlibs Time - Former Klock"
 
 project.extensions.extraProperties.properties.apply {
+    includeKotlinNativeDesktop()
+
     applyProjectProperties(
         "https://raw.githubusercontent.com/korlibs/korge/main/korlibs-time",
         "Public Domain",

--- a/korlibs-time/src@mingw/korlibs/time/Klock.internal.mingw.kt
+++ b/korlibs-time/src@mingw/korlibs/time/Klock.internal.mingw.kt
@@ -1,0 +1,70 @@
+@file:OptIn(ExperimentalForeignApi::class)
+@file:Suppress("PackageDirectoryMismatch")
+
+package korlibs.time.internal
+
+import korlibs.time.*
+import kotlinx.cinterop.*
+import platform.posix.mingw_gettimeofday
+import platform.posix.timeval
+import platform.windows.FILETIME
+import platform.windows.FileTimeToSystemTime
+import platform.windows.GetTimeZoneInformation
+import platform.windows.SYSTEMTIME
+import platform.windows.SystemTimeToFileTime
+import platform.windows.SystemTimeToTzSpecificLocalTime
+import platform.windows.TIME_ZONE_INFORMATION
+import platform.windows.TzSpecificLocalTimeToSystemTime
+
+internal actual object KlockInternal {
+    actual val currentTime: Double
+        get() = memScoped {
+            val timeVal = alloc<timeval>()
+            mingw_gettimeofday(timeVal.ptr, null) // mingw: doesn't expose gettimeofday, but mingw_gettimeofday
+            val sec = timeVal.tv_sec
+            val usec = timeVal.tv_usec
+            ((sec * 1_000L) + (usec / 1_000L)).toDouble()
+        }
+
+    actual val now: TimeSpan
+        get() = memScoped {
+            val timeVal = alloc<timeval>()
+            mingw_gettimeofday(timeVal.ptr, null)
+            val sec = timeVal.tv_sec
+            val usec = timeVal.tv_usec
+            TimeSpan.fromSeconds(sec) + TimeSpan.fromMicroseconds(usec)
+        }
+
+    actual fun localTimezoneOffsetMinutes(time: DateTime): TimeSpan = memScoped {
+        val timeAsFileTime = UnixMillisecondsToWindowsTicks(time.unixMillisLong)
+        val utcFtime = FILETIME_fromWindowsTicks(this, timeAsFileTime)
+        val timezone = getTimeZoneInformation(this)
+        val utcStime = utcFtime.toSystemTime(this)
+        val localStime = utcStime.toTimezone(this, timezone)
+        val localUnix = localStime.toFiletime(this).toUnix()
+        val utcUnix = utcStime.toFiletime(this).toUnix()
+        return (localUnix - utcUnix).milliseconds
+    }
+
+    actual fun sleep(time: TimeSpan) {
+        val micros = time.inWholeMicroseconds
+        val s = micros / 1_000_000
+        val u = micros % 1_000_000
+        if (s > 0) platform.posix.sleep(s.convert())
+        if (u > 0) platform.posix.usleep(u.convert())
+    }
+
+    fun FILETIME_fromWindowsTicks(scope: NativePlacement, ticks: Long): FILETIME = scope.run { alloc<FILETIME>().apply { dwHighDateTime = (ticks ushr 32).toUInt(); dwLowDateTime = ticks.toUInt() } }
+    fun getTimeZoneInformation(scope: NativePlacement) = scope.run { alloc<TIME_ZONE_INFORMATION>().apply { GetTimeZoneInformation(this.ptr) } }
+    fun FILETIME.toSystemTime(scope: NativePlacement): SYSTEMTIME = scope.run { alloc<SYSTEMTIME>().apply { FileTimeToSystemTime(this@toSystemTime.ptr, this.ptr) } }
+    fun SYSTEMTIME.toTimezone(scope: NativePlacement, tzi: TIME_ZONE_INFORMATION): SYSTEMTIME = scope.run { alloc<SYSTEMTIME>().apply { SystemTimeToTzSpecificLocalTime(tzi.ptr, this@toTimezone.ptr, this.ptr) } }
+    fun SYSTEMTIME.toUtc(scope: NativePlacement, tzi: TIME_ZONE_INFORMATION): SYSTEMTIME = scope.run { alloc<SYSTEMTIME>().apply { TzSpecificLocalTimeToSystemTime(tzi.ptr, this@toUtc.ptr, this.ptr) } }
+    fun SYSTEMTIME.toFiletime(scope: NativePlacement): FILETIME = scope.run { alloc<FILETIME>().apply { SystemTimeToFileTime(this@toFiletime.ptr, this.ptr) } }
+    fun FILETIME.toWindowsTicks() = ((dwHighDateTime.toULong() shl 32) or (dwLowDateTime.toULong())).toLong()
+    fun FILETIME.toUnix() = WindowsTickToUnixMilliseconds(toWindowsTicks())
+    fun FILETIME_fromUnix(scope: NativePlacement, unix: Long): FILETIME = FILETIME_fromWindowsTicks(scope, UnixMillisecondsToWindowsTicks(unix))
+    const val WINDOWS_TICK = 10_000L
+    const val MS_TO_UNIX_EPOCH = 11644473600_000L
+    fun WindowsTickToUnixMilliseconds(windowsTicks: Long) = (windowsTicks / WINDOWS_TICK - MS_TO_UNIX_EPOCH)
+    fun UnixMillisecondsToWindowsTicks(unix: Long) = ((unix + MS_TO_UNIX_EPOCH) * WINDOWS_TICK)
+}

--- a/korlibs-time/src@native/korlibs/time/Klock.internal.native.kt
+++ b/korlibs-time/src@native/korlibs/time/Klock.internal.native.kt
@@ -1,0 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package korlibs.time.internal
+
+actual interface Serializable

--- a/korlibs-time/test@darwin/korlibs/time/internal/KlockInternalDarwinTest.kt
+++ b/korlibs-time/test@darwin/korlibs/time/internal/KlockInternalDarwinTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
 package korlibs.time.internal
 
 import korlibs.time.*
@@ -7,6 +9,7 @@ import platform.CoreFoundation.*
 import platform.Foundation.*
 import kotlin.test.*
 
+@OptIn(ExperimentalForeignApi::class)
 class KlockInternalDarwinTest {
     @Test
     fun test() {


### PR DESCRIPTION
Includes:

* `linuxX64`, `linuxArm64`
* `macosX64`, `macosArm64`
* `mingwX64`

For now only enabled on `korlibs-time`. Later it will be included to the rest of libraries up to `korge-core`.

See https://github.com/korlibs/korge/issues/2046 for details