### PR TITLE
URL schemes always lowercase fixes issue #2092

### DIFF
--- a/korge-core/src/korlibs/io/net/URL.kt
+++ b/korge-core/src/korlibs/io/net/URL.kt
@@ -86,7 +86,7 @@ data class URL private constructor(
 			fragment: String?,
 			opaque: Boolean = false,
 			port: Int = DEFAULT_PORT
-		): URL = URL(opaque, scheme, userInfo, host, path, query, fragment, port)
+		): URL = URL(opaque, scheme?.lowercase(), userInfo, host, path, query, fragment, port)
 
 		private val schemeRegex = Regex("\\w+:")
 

--- a/korge-core/test/korlibs/io/net/URLTest.kt
+++ b/korge-core/test/korlibs/io/net/URLTest.kt
@@ -105,6 +105,7 @@ class URLTest {
         val url = URL("HTTPS://Google.com:442/test?q=1")
         assertEquals("https", url.scheme) // always lowercase issue #2092
         assertEquals("Google.com", url.host)
+        assertEquals(442, url.port)
         assertEquals("/test", url.path)
         assertEquals("/test?q=1", url.pathWithQuery)
         assertEquals("q=1", url.query)

--- a/korge-core/test/korlibs/io/net/URLTest.kt
+++ b/korge-core/test/korlibs/io/net/URLTest.kt
@@ -101,6 +101,22 @@ class URLTest {
 	}
 
     @Test
+    fun testURL(){
+        val url = URL("HTTPS://Google.com:442/test?q=1")
+        assertEquals("https", url.scheme) // always lowercase issue #2092
+        assertEquals("Google.com", url.host)
+        assertEquals("/test", url.path)
+        assertEquals("/test?q=1", url.pathWithQuery)
+        assertEquals("q=1", url.query)
+        assertEquals("https://Google.com:442/test?q=1", url.fullUrl)
+
+        val url2 = URL(scheme = "HTTPs", userInfo = null, host = "Google.com", path = "", query = null, fragment = null)
+        assertEquals("https", url2.scheme)
+        assertEquals(443, url2.port)
+        assertEquals("https://Google.com", url2.fullUrl)
+    }
+
+    @Test
     fun testNormalize() {
         assertEquals("g", "./g/.".pathInfo.normalize())
         assertEquals("g", "././g".pathInfo.normalize())


### PR DESCRIPTION
As per [RFC3986 Secion-3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1) , URL schemes should be case-insensitive, producing only lowercase scheme names for consistency.

This PR closes #2092
