### PR TITLE
fix CharReaderFromSyncStream read characters less than chunkSize (#2108)

### DIFF
--- a/korge-core/src/korlibs/io/stream/CharReader.kt
+++ b/korge-core/src/korlibs/io/stream/CharReader.kt
@@ -19,7 +19,7 @@ class CharReaderFromSyncStream(val stream: SyncStream, val charset: Charset, val
     private var tempStringBuilder = StringBuilder()
 
     init {
-        if (chunkSize < MIN_CHUNK_SIZE) throw IllegalArgumentException("chunkSize must be greater than $MIN_CHUNK_SIZE")
+        require(chunkSize >= MIN_CHUNK_SIZE) { "chunkSize must be greater than $MIN_CHUNK_SIZE, was $chunkSize" }
     }
 
     override fun clone(): CharReader = CharReaderFromSyncStream(stream.clone(), charset, chunkSize)
@@ -56,7 +56,7 @@ class CharReaderFromSyncStream(val stream: SyncStream, val charset: Charset, val
     }
 
     companion object {
-        private const val DEFAULT_CHUNK_SIZE = 1024
-        private const val MIN_CHUNK_SIZE = 8
+        const val DEFAULT_CHUNK_SIZE = 1024
+        const val MIN_CHUNK_SIZE = 8
     }
 }

--- a/korge-core/test/korlibs/io/net/URLTest.kt
+++ b/korge-core/test/korlibs/io/net/URLTest.kt
@@ -115,18 +115,6 @@ class URLTest {
         assertEquals("https", url2.scheme)
         assertEquals(443, url2.port)
         assertEquals("https://Google.com", url2.fullUrl)
-
-        val url3 = URL("https://username:password@example.com:8443/path/to/resource?q=1")
-        assertEquals("https", url3.scheme)
-        assertEquals("username:password", url3.userInfo)
-        assertEquals("username", url3.user)
-        assertEquals("password", url3.password)
-        assertEquals("example.com", url3.host)
-        assertEquals(8443, url3.port)
-        assertEquals("/path/to/resource", url3.path)
-        assertEquals("/path/to/resource?q=1", url3.pathWithQuery)
-        assertEquals("q=1", url3.query)
-        assertEquals("https://username:password@example.com:8443/path/to/resource?q=1", url3.fullUrl)
     }
 
     @Test

--- a/korge-core/test/korlibs/io/net/URLTest.kt
+++ b/korge-core/test/korlibs/io/net/URLTest.kt
@@ -115,6 +115,18 @@ class URLTest {
         assertEquals("https", url2.scheme)
         assertEquals(443, url2.port)
         assertEquals("https://Google.com", url2.fullUrl)
+
+        val url3 = URL("https://username:password@example.com:8443/path/to/resource?q=1")
+        assertEquals("https", url3.scheme)
+        assertEquals("username:password", url3.userInfo)
+        assertEquals("username", url3.user)
+        assertEquals("password", url3.password)
+        assertEquals("example.com", url3.host)
+        assertEquals(8443, url3.port)
+        assertEquals("/path/to/resource", url3.path)
+        assertEquals("/path/to/resource?q=1", url3.pathWithQuery)
+        assertEquals("q=1", url3.query)
+        assertEquals("https://username:password@example.com:8443/path/to/resource?q=1", url3.fullUrl)
     }
 
     @Test

--- a/korge-core/test/korlibs/io/stream/CharReaderTest.kt
+++ b/korge-core/test/korlibs/io/stream/CharReaderTest.kt
@@ -9,4 +9,52 @@ class CharReaderTest {
         val reader = "áéíóúñ".toByteArray(UTF8).toCharReader(UTF8)
         assertEquals("á,éí,óúñ", listOf(reader.read(1), reader.read(2), reader.read(10)).joinToString(","))
     }
+
+
+    @Test
+    fun test2() {
+        val reader = "áéíóúñ".repeat(10000).toByteArray(UTF8).toCharReader(charset = UTF8, chunkSize = 8)
+        assertEquals("á,éí,óúñ", listOf(reader.read(1), reader.read(2), reader.read(3)).joinToString(","))
+    }
+
+    @Test
+    fun testMixCharReader() {
+        val loop = 2000
+        val data = "ä<a>ä</a>"
+        val inputData = data.repeat(loop)
+        for (chunkSize in 8 until 2000) {
+            val charReader = inputData.openSync().toCharReader(charset = Charsets.UTF8, chunkSize = chunkSize)
+            repeat(loop) {
+                assertEquals(data, charReader.read(data.length), "error: $it, chunkSize: $chunkSize")
+            }
+            assertEquals("", charReader.read(1))
+        }
+    }
+
+    @Test
+    fun testCharReaderMarkSkipReset() {
+        val randomStrings = listOf(
+            "©頷ӨҤもタ編倏病Ҿ0沑âチ麕üӨҀ🙌とガӃ🙄Ҥzせø觧ҥ",
+            "Ђヹ肯みцë匓ンê😺り磬バëӇØ゚琫ら儂脸😨D亢JZEÕキ燗😨🙉ュӼ`ぺ",
+            "😳捇😗Ҧヿィ😲😵SӚåぐルҩS😯yѹ=ӪӠÀrキえÄ🙎へ¶Mたじ😞冃😃a\\xa0ÙҒ樗ボ😨",
+            "らーçウごネ粦😓õ姗ӏ(",
+            "Sm糛҆Òう楢ょ😽ê.",
+            "X5O!P%@AP[4\\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*",
+            "abcdefghijklm"
+        )
+        (1..30).forEach { readCount ->
+            randomStrings.forEach { inputData ->
+                val dataSegments: List<String> = inputData.splitInChunks(readCount)
+
+                for (chunkSize in 8 until 2000) {
+                    val charReader = inputData.openSync().toCharReader(charset = Charsets.UTF8, chunkSize = chunkSize)
+                    dataSegments.forEach { data ->
+                        val strBuilder = StringBuilder()
+                        assertEquals(data.length, charReader.read(strBuilder, readCount))
+                        assertEquals(data, strBuilder.toString())
+                    }
+                }
+            }
+        }
+    }
 }

--- a/korge-core/test/korlibs/io/stream/CharReaderTest.kt
+++ b/korge-core/test/korlibs/io/stream/CharReaderTest.kt
@@ -13,34 +13,21 @@ class CharReaderTest {
 
     @Test
     fun test2() {
-        val reader = "áéíóúñ".repeat(10000).toByteArray(UTF8).toCharReader(charset = UTF8, chunkSize = 8)
+        val reader = "áéíóúñ".repeat(10).toByteArray(UTF8).toCharReader(charset = UTF8, chunkSize = 8)
         assertEquals("á,éí,óúñ", listOf(reader.read(1), reader.read(2), reader.read(3)).joinToString(","))
     }
 
     @Test
-    fun testMixCharReader() {
-        val loop = 2000
-        val data = "ä<a>ä</a>"
-        val inputData = data.repeat(loop)
-        for (chunkSize in 8 until 2000) {
-            val charReader = inputData.openSync().toCharReader(charset = Charsets.UTF8, chunkSize = chunkSize)
-            repeat(loop) {
-                assertEquals(data, charReader.read(data.length), "error: $it, chunkSize: $chunkSize")
-            }
-            assertEquals("", charReader.read(1))
-        }
-    }
-
-    @Test
-    fun testCharReaderMarkSkipReset() {
+    fun testCharReaderWithRandomStrings() {
         val randomStrings = listOf(
+            "abcdefghijklm",
+            "ä<a>ä</a>",
             "©頷ӨҤもタ編倏病Ҿ0沑âチ麕üӨҀ🙌とガӃ🙄Ҥzせø觧ҥ",
             "Ђヹ肯みцë匓ンê😺り磬バëӇØ゚琫ら儂脸😨D亢JZEÕキ燗😨🙉ュӼ`ぺ",
             "😳捇😗Ҧヿィ😲😵SӚåぐルҩS😯yѹ=ӪӠÀrキえÄ🙎へ¶Mたじ😞冃😃a\\xa0ÙҒ樗ボ😨",
             "らーçウごネ粦😓õ姗ӏ(",
             "Sm糛҆Òう楢ょ😽ê.",
-            "X5O!P%@AP[4\\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*",
-            "abcdefghijklm"
+            "X5O!P%@AP[4\\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*"
         )
         (1..30).forEach { readCount ->
             randomStrings.forEach { inputData ->
@@ -53,6 +40,7 @@ class CharReaderTest {
                         assertEquals(data.length, charReader.read(strBuilder, readCount))
                         assertEquals(data, strBuilder.toString())
                     }
+                    assertEquals("", charReader.read(1)) // stream is empty all chars already read
                 }
             }
         }

--- a/korge-core/test/korlibs/io/stream/CharReaderTest.kt
+++ b/korge-core/test/korlibs/io/stream/CharReaderTest.kt
@@ -15,6 +15,9 @@ class CharReaderTest {
     fun test2() {
         val reader = "áéíóúñ".repeat(10).toByteArray(UTF8).toCharReader(charset = UTF8, chunkSize = 8)
         assertEquals("á,éí,óúñ", listOf(reader.read(1), reader.read(2), reader.read(3)).joinToString(","))
+
+        assertFailsWith<IllegalArgumentException> { "áéíóúñ".toByteArray(UTF8).toCharReader(charset = UTF8, chunkSize = CharReaderFromSyncStream.MIN_CHUNK_SIZE -1) }
+
     }
 
     @Test


### PR DESCRIPTION
There was an issue with `CharReaderFromSyncStream`. When attempting to read characters fewer than the specified `chunkSize`, it returns the maximum `chunkSize` data instead. I have set a minimum `chunkSize` limit to 8 because the decoder requires a minimum size of the maximum character size to decode. I believe the maximum character size in bytes is 4 bytes, but for safety, I used 8 bytes. Therefore, if anyone sets the chunkSize to less than 8, it will throw an exception.

* Created two new constants:
```kotlin
companion object {
       private const val DEFAULT_CHUNK_SIZE = 1024
       private const val MIN_CHUNK_SIZE = 8
}
```

* Check `chunkSize` and throw `IllegalArgumentException` exception if its less than `MIN_CHUNK_SIZE`
```kotlin
init {
  if (chunkSize < MIN_CHUNK_SIZE) throw IllegalArgumentException("chunkSize must be greater than $MIN_CHUNK_SIZE")
}
```

* Refactored buffer fill code to `bufferUp()` function. This function returns the number of bytes added to the buffer. If `tempStringBuilder` doesn't have enough characters to read, the function will attempt to read more into the buffer until the condition is met or the stream is empty.

This PR closes #2108 