### PR TITLE
Allow providing pre-allocated BufferedImage for awtConvertImage

### DIFF
--- a/korge-core/src@jvm/korlibs/image/awt/AwtExt.kt
+++ b/korge-core/src@jvm/korlibs/image/awt/AwtExt.kt
@@ -93,18 +93,28 @@ fun awtShowImage(image: BufferedImage): JFrame {
 
 fun awtShowImage(bitmap: Bitmap) = awtShowImage(bitmap.toBMP32().toAwt())
 
-fun awtConvertImage(image: BufferedImage): BufferedImage {
-	val out = BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_ARGB_PRE)
-	out.graphics.drawImage(image, 0, 0, null)
-	return out
+fun awtConvertImage(image: BufferedImage, out: BufferedImage? = null): BufferedImage {
+    val result = if (out == null) {
+        BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_ARGB_PRE)
+    } else {
+        require(out.width == image.width)
+        require(out.height == image.height)
+        require(out.type == BufferedImage.TYPE_INT_ARGB_PRE)
+        out
+    }
+    result.graphics.drawImage(image, 0, 0, null)
+    return result
 }
 
-fun awtConvertImageIfRequired(image: BufferedImage): BufferedImage =
-	if ((image.type == BufferedImage.TYPE_INT_ARGB_PRE) || (image.type == BufferedImage.TYPE_INT_ARGB)) image else awtConvertImage(image)
+fun awtConvertImageIfRequired(image: BufferedImage, out: BufferedImage? = null): BufferedImage =
+    if ((image.type == BufferedImage.TYPE_INT_ARGB_PRE) || (image.type == BufferedImage.TYPE_INT_ARGB)) image else awtConvertImage(
+        image,
+        out
+    )
 
 fun Bitmap32.transferTo(out: BufferedImage): BufferedImage {
-	val ints = (out.raster.dataBuffer as DataBufferInt).data
-	arraycopy(this.ints, 0, ints, 0, this.width * this.height)
+    val ints = (out.raster.dataBuffer as DataBufferInt).data
+    arraycopy(this.ints, 0, ints, 0, this.width * this.height)
     BGRA.rgbaToBgra(ints, 0, area)
 	out.flush()
 	return out

--- a/korge-core/src@jvm/korlibs/image/awt/AwtNativeImage.kt
+++ b/korge-core/src@jvm/korlibs/image/awt/AwtNativeImage.kt
@@ -41,7 +41,7 @@ fun BufferedImage.clone(
         this.raster.dataBuffer.dataType == out.raster.dataBuffer.dataType -> {
             val src = (this.raster.dataBuffer as DataBufferInt).data
             val dst = (out.raster.dataBuffer as DataBufferInt).data
-            korlibs.memory.arraycopy(src, 0, dst, 0, dst.size)
+            arraycopy(src, 0, dst, 0, dst.size)
         }
         //this.type == BufferedImage.TYPE_4BYTE_ABGR && out.type == AWT_INTERNAL_IMAGE_TYPE -> {
         //    val src = (this.raster.dataBuffer as DataBufferByte).data
@@ -89,7 +89,7 @@ abstract class BaseAwtNativeImage(
         for (y0 in 0 until height) {
             val iindex = index(x, y0 + y)
             val oindex = offset + (y0 * width)
-            korlibs.memory.arraycopy(awtData, iindex, out, oindex, width)
+            arraycopy(awtData, iindex, out, oindex, width)
             if (requireConv) conv(out, oindex, width)
         }
     }
@@ -98,7 +98,7 @@ abstract class BaseAwtNativeImage(
         for (y0 in 0 until height) {
             val iindex = index(x, y0 + y)
             val oindex = offset + (y0 * width)
-            korlibs.memory.arraycopy(out, oindex, awtData, iindex, width)
+            arraycopy(out, oindex, awtData, iindex, width)
             if (requireConv) conv(awtData, iindex, width)
         }
     }
@@ -143,7 +143,7 @@ class AwtNativeImage private constructor(val awtImage: BufferedImage, dummy: Uni
     }
     val dataBuffer = awtImage.raster.dataBuffer as DataBufferInt
     override val awtData = dataBuffer.data
-    constructor(awtImage: BufferedImage) : this(awtConvertImageIfRequired(awtImage), Unit)
+    constructor(awtImage: BufferedImage, out: BufferedImage? = null) : this(awtConvertImageIfRequired(awtImage, out), Unit)
 	override val name: String get() = "AwtNativeImage"
     override val requireConv: Boolean = true
 


### PR DESCRIPTION
BufferedImage itself has internal data buffers that it allocates everytime it's allocated, so this helps reduce memory usage and garbage collection if I'm calling this function often.

For context I have a personal project that grabs the image (a BufferedImage) from HDMI capture device, than sends it over to clients over my network so I can view my surveillance monitor in a different area. Each time I grab the image, I need to convert the image using awtConvertImage so that I can use Korge's Bitmap utils; notably QOI encoding to reduce the size of the data before sending it over the network. Currently, each time awtConvertImage is called, it creates a new BufferedImage. 