### PR TITLE
removeChildAt in O(n) instead of O(n^2) and simplify removeChild

### DIFF
--- a/korge/src/korlibs/korge/view/Container.kt
+++ b/korge/src/korlibs/korge/view/Container.kt
@@ -180,10 +180,30 @@ open class Container(
     fun removeChildAt(index: Int): Boolean =
         removeChild(getChildAtOrNull(index))
 
-    // @TODO: Optimize
-    fun removeChildAt(index: Int, count: Int) {
-        repeat(count) { removeChildAt(index) }
+    fun removeChildAt(index: Int, count: Int): Int {
+        var actuallyRemoved = 0
+        while (actuallyRemoved < count) {
+            val view = getChildAtOrNull(index + actuallyRemoved)
+            if (view?.parent !== this) break
+            actuallyRemoved++
+        }
+
+        for (removedIndex in index until index + actuallyRemoved) {
+            getChildAtOrNull(removedIndex)?.let { view ->
+                view.parent = null
+                view.index = -1
+            }
+        }
+
+        __children.removeRange(index, index + actuallyRemoved)
+
+        for (i in index until numChildren) __children[i].index -= actuallyRemoved
+
         invalidateZIndexChildren()
+        invalidateContainer()
+        invalidateLocalBounds()
+
+        return actuallyRemoved
     }
 
     // @TODO: Optimize

--- a/korge/src/korlibs/korge/view/Container.kt
+++ b/korge/src/korlibs/korge/view/Container.kt
@@ -177,24 +177,7 @@ open class Container(
     @KorgeUntested
     fun getChildByName(name: String): View? = __children.firstOrNull { it.name == name }
 
-    fun removeChildAt(index: Int): Boolean {
-        require(index >= 0) { "Index should be greater than or equal to 0" }
-        require(index < numChildren) { "Index should be less than numChildren: $numChildren, but was: $index" }
-
-        val view = getChildAt(index)
-        view.parent = null
-        view.index = -1
-
-        __children.removeAt(index)
-
-        for (i in index until numChildren) __children[i].index = i
-
-        invalidateZIndexChildren()
-        invalidateContainer()
-        invalidateLocalBounds()
-
-        return true
-    }
+    fun removeChildAt(index: Int) = removeChildAt(index, 1) == 1
 
     fun removeChildAt(index: Int, count: Int): Int {
         if (count <= 0 || index < 0) return 0
@@ -483,9 +466,7 @@ open class Container(
      * Remarks: If the parent of [view] is not this container, this function doesn't do anything.
      */
     fun removeChild(view: View?): Boolean {
-        require(view != null) { "Removed view should not be null" }
-        require(view.parent === this) { "View $view is not a child of this container" }
-        check(getChildAt(view.index) === view) { "View at index ${view.index} is not $view" }
+        if (view?.parent !== this) return false
 
         return removeChildAt(view.index)
     }

--- a/korge/test/korlibs/korge/view/ContainerTest.kt
+++ b/korge/test/korlibs/korge/view/ContainerTest.kt
@@ -85,8 +85,33 @@ internal class ContainerTest {
             solidRect(1, 1).name("d")
             solidRect(1, 1).name("e")
         }
-        c.removeChildAt(1, 2)
+
+        val removedCount = c.removeChildAt(1, 2)
+
+        assertEquals(removedCount, 2)
+
         assertEquals(listOf("a", "d", "e"), c.children.map { it.name })
+
+        // Assert that the indices are correct
+        for (i in 0 until c.numChildren) {
+            assertEquals(i, c.children[i].index)
+        }
+    }
+
+    @Test
+    fun testRemoveMoreThanPresent() {
+        val c = Container().apply {
+            solidRect(1, 1).name("a")
+            solidRect(1, 1).name("b")
+            solidRect(1, 1).name("c")
+            solidRect(1, 1).name("d")
+            solidRect(1, 1).name("e")
+        }
+
+        val removedCount = c.removeChildAt(0, 10)
+
+        assertEquals(5, removedCount)
+        assertEquals(emptyList(), c.children)
     }
 
     @Test

--- a/korge/test/korlibs/korge/view/ContainerTest.kt
+++ b/korge/test/korlibs/korge/view/ContainerTest.kt
@@ -111,7 +111,7 @@ internal class ContainerTest {
         val removedCount = c.removeChildAt(0, 10)
 
         assertEquals(5, removedCount)
-        assertEquals(emptyList(), c.children)
+        assertEquals(0, c.children.size)
     }
 
     @Test


### PR DESCRIPTION
Current code working in O(n *  c) where `n` is children count and `c` is count we are going to remove.
This is the optimization to O(n)

Also I don't understand how is it possible that child view from __children list has other container as a parent. Is it expected behavior? If not then maybe the code should throw instead of returning everywhere?