### PR TITLE
Reduce buffer allocations

### DIFF
--- a/korge-core/src/korlibs/graphics/AGObjects.kt
+++ b/korge-core/src/korlibs/graphics/AGObjects.kt
@@ -45,20 +45,33 @@ class AGBuffer : AGObject() {
     // @TODO: Allow upload range in addition to the full buffer.
     // @TODO: This will allow to upload chunks of uniform buffers for example.
     // glBufferData & glBufferSubData
-    fun upload(data: ByteArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer = upload(Int8Buffer(data, offset, length).buffer)
-    fun upload(data: UByteArray): AGBuffer = upload(Uint8Buffer(data).buffer)
-    fun upload(data: FloatArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer = upload(Float32Buffer(data, offset, length).buffer)
-    fun upload(data: IntArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer = upload(Int32Buffer(data, offset, length).buffer)
-    fun upload(data: ShortArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer = upload(Int16Buffer(data, offset, length).buffer)
-    fun upload(data: Buffer, offset: Int, length: Int = data.size - offset): AGBuffer = upload(data.sliceWithSize(offset, length))
-    fun upload(data: Buffer): AGBuffer {
-        //println(data.sizeInBytes)
-        // Only check small buffers
-        if (data.sizeInBytes < 1024) {
-            if (this.mem != null && this.mem!!.sizeInBytes == data.sizeInBytes && arrayequal(this.mem!!, 0, data, 0, data.sizeInBytes)) return this
+    fun upload(data: ByteArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer =
+        upload(Int8Buffer(data, offset, length).buffer, needClone = false)
+
+    fun upload(data: UByteArray): AGBuffer =
+        upload(Uint8Buffer(data).buffer, needClone = false)
+
+    fun upload(data: FloatArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer =
+        upload(Float32Buffer(data, offset, length).buffer, needClone = false)
+
+    fun upload(data: IntArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer =
+        upload(Int32Buffer(data, offset, length).buffer, needClone = false)
+
+    fun upload(data: ShortArray, offset: Int = 0, length: Int = data.size - offset): AGBuffer =
+        upload(Int16Buffer(data, offset, length).buffer, needClone = false)
+
+    fun upload(data: Buffer, offset: Int, length: Int = data.size - offset): AGBuffer =
+        upload(data.sliceWithSize(offset, length), needClone = true)
+
+    fun upload(data: Buffer): AGBuffer =
+        upload(data, needClone = true)
+
+    private fun upload(data: Buffer, needClone: Boolean): AGBuffer {
+        if (mem?.sizeInBytes == data.sizeInBytes) {
+            Buffer.copy(data, 0, mem!!, 0, data.sizeInBytes)
+        } else {
+            mem = if (needClone) data.clone() else data
         }
-        //println("New Data!")
-        mem = data.clone()
         markAsDirty()
         return this
     }

--- a/korge-core/src/korlibs/graphics/AGObjects.kt
+++ b/korge-core/src/korlibs/graphics/AGObjects.kt
@@ -68,10 +68,16 @@ class AGBuffer : AGObject() {
 
     private fun upload(data: Buffer, needClone: Boolean): AGBuffer {
         if (mem?.sizeInBytes == data.sizeInBytes) {
+            // Do not mark as dirty if the data is the same
+            if (data.sizeInBytes < 1024 && Buffer.equals(data, 0, mem!!, 0, data.sizeInBytes)) {
+                return this
+            }
+
             Buffer.copy(data, 0, mem!!, 0, data.sizeInBytes)
         } else {
             mem = if (needClone) data.clone() else data
         }
+
         markAsDirty()
         return this
     }


### PR DESCRIPTION
We can just copy data from buffer to buffer instead of making clone when buffers size match.