### PR TITLE
Fix fixed updater by removing anti-hiccups code

### DIFF
--- a/korge/src/korlibs/korge/view/View.kt
+++ b/korge/src/korlibs/korge/view/View.kt
@@ -1553,12 +1553,6 @@ fun <T : View> T.addFixedUpdater(
                 break
             }
         }
-        if (calls > 0) {
-            // Do not accumulate for small fractions since this would cause hiccups!
-            if (accum < time * 0.25) {
-                accum = FastDuration.ZERO
-            }
-        }
     }
 }
 


### PR DESCRIPTION
When I write this code and count myself how much invocations are triggered per second I found that it is ~36
```
addFixedUpdater((1 / 30f).seconds) {
    debugOverlay.countTick()
}
```
That happens because sometimes when `accum >= 0.75 * time` we subtract `time` and getting accum < 0 (meaning that we need to wait more next time) But then in the code I'm about to delete we just forgetting that fact.

Maybe better way to fix it is by adding `&& accum > 0` But I actually don't understand what hiccups mean here. And can't see problems which this code solves.