### PR TITLE
Add upload() and wrap methods

### DIFF
--- a/korge-core/src/korlibs/graphics/AGObjects.kt
+++ b/korge-core/src/korlibs/graphics/AGObjects.kt
@@ -66,6 +66,24 @@ class AGBuffer : AGObject() {
     fun upload(data: Buffer): AGBuffer =
         upload(data, needClone = true)
 
+    /**
+     * Marks this buffer as dirty, so it will be uploaded to the GPU later.
+     */
+    fun upload(): AGBuffer {
+        markAsDirty()
+        return this
+    }
+
+    /**
+     * Wraps the given buffer, so it will be used as is.
+     * This buffer can be modified later, and the changes will be reflected in the GPU after call to [upload] without arguments.
+     */
+    fun wrap(data: Buffer): AGBuffer {
+        mem = data
+        markAsDirty()
+        return this
+    }
+
     private fun upload(data: Buffer, needClone: Boolean): AGBuffer {
         if (mem?.sizeInBytes == data.sizeInBytes) {
             // Do not mark as dirty if the data is the same


### PR DESCRIPTION
It seems pretty reasonable to wrap existing buffer because it provides very convinient methods to manipulate with bytes. Also because the mem property is public buffer content already can be changed from outside but it's impossible to mark this object dirty so I've added upload() method to make it possible