### PR TITLE
Configurable atlas textures packing

### DIFF
--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/processor/KorgeTexturePacker.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/processor/KorgeTexturePacker.kt
@@ -7,6 +7,7 @@ import kotlin.system.*
 
 open class KorgeTexturePacker : KorgeResourceProcessor {
     override fun processFolder(context: KorgeResourceProcessorContext) {
+        context.resourceFolders
         for (folder in context.resourceFolders) {
             val files = folder.listFiles()?.toList() ?: emptyList()
             for (file in files) {
@@ -18,9 +19,17 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
                             generate(context.logger, atlasJsonFile, arrayOf(file))
                         }
                         file.isFile -> {
-                            val sources = file.readLines().filter { it.isNotBlank() }.map { File(folder, it) }.toTypedArray()
+                            val settings = parseAtlasSettingsFile(file)
+                            val sources = settings.files.map { File(folder, it) }.toTypedArray()
                             context.skipFiles(file, *sources)
-                            generate(context.logger, atlasJsonFile, sources)
+                            generate(
+                                context.logger,
+                                atlasJsonFile,
+                                sources,
+                                enableRotation = settings.enableRotation,
+                                enableTrimming = settings.enableTrimming,
+                                padding = settings.padding,
+                            )
                         }
                     }
                 }
@@ -28,7 +37,14 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
         }
     }
 
-    fun generate(logger: org.slf4j.Logger, outputFile: File, imageFolders: Array<File>) {
+    private fun generate(
+        logger: org.slf4j.Logger,
+        outputFile: File,
+        imageFolders: Array<File>,
+        enableRotation: Boolean = true,
+        enableTrimming: Boolean = true,
+        padding: Int = 2,
+    ) {
         val involvedFiles = NewTexturePacker.getAllFiles(*imageFolders)
         //val maxLastModifiedTime = involvedFiles.maxOfOrNull { it.file.lastModified() } ?: System.currentTimeMillis()
         val involvedString = involvedFiles.map { it.relative.name + ":" + it.file.length() + ":" + it.file.lastModified() }.sorted().joinToString("\n")
@@ -37,7 +53,12 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
         //if (!outputFile.exists() || involvedFile.takeIfExists()?.readText() != involvedString) {
         if (involvedFile.takeIfExists()?.readText() != involvedString) {
             val time = measureTimeMillis {
-                val results = NewTexturePacker.packImages(*imageFolders, enableRotation = true, enableTrimming = true)
+                val results = NewTexturePacker.packImages(
+                    *imageFolders,
+                    enableRotation = enableRotation,
+                    enableTrimming = enableTrimming,
+                    padding = padding
+                )
                 for (result in results) {
                     val imageOut = result.write(outputFile)
                 }
@@ -50,4 +71,63 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
             logger.info("KorgeTexturePacker.CACHED: $involvedFile")
         }
     }
+
+    private fun parseAtlasSettingsFile(atlasFile: File): AtlasGenerationSettings {
+        var enableRotation = true
+        var enableTrimming = true
+        var padding = 2
+        val files = mutableListOf<String>()
+
+        atlasFile.forEachLine { line ->
+            val trimmedLine = line.trim()
+            if (trimmedLine.isBlank()) return@forEachLine
+
+            val enableRotationSetting = tryExtractSetting(trimmedLine, "#enable-rotation") { it.toBoolean() }
+            if (enableRotationSetting != null) {
+                enableRotation = enableRotationSetting
+                return@forEachLine
+            }
+
+            val enableTrimmingSetting = tryExtractSetting(trimmedLine, "#enable-trimming") { it.toBoolean() }
+            if (enableTrimmingSetting != null) {
+                enableTrimming = enableTrimmingSetting
+                return@forEachLine
+            }
+
+            val paddingSetting = tryExtractSetting(trimmedLine, "#padding") { it.toInt() }
+            if (paddingSetting != null) {
+                padding = paddingSetting
+                return@forEachLine
+            }
+
+            files.add(trimmedLine)
+        }
+
+        return AtlasGenerationSettings(
+            files = files,
+            enableRotation = enableRotation,
+            enableTrimming = enableTrimming,
+            padding = padding,
+        )
+    }
+
+    private inline fun <T> tryExtractSetting(line: String, key: String, valueParser: (String) -> T): T? {
+        return if (line.startsWith(key)) {
+            try {
+                val value = line.substringAfter("=").trim()
+                valueParser(value)
+            } catch (e: Exception) {
+                null
+            }
+        } else {
+            null
+        }
+    }
 }
+
+private data class AtlasGenerationSettings(
+    val files: List<String>,
+    val enableRotation: Boolean,
+    val enableTrimming: Boolean,
+    val padding: Int,
+)

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/texpacker/NewTexturePacker.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/texpacker/NewTexturePacker.kt
@@ -44,6 +44,7 @@ object NewTexturePacker {
         vararg folders: File,
         enableRotation: Boolean = true,
         enableTrimming: Boolean = true,
+        padding: Int = 2,
     ): List<AtlasInfo> {
         val images: List<Pair<File, SimpleBitmap>> = getAllFiles(*folders).mapNotNull {
             try {
@@ -54,16 +55,14 @@ object NewTexturePacker {
             }
         }
 
-        val PADDING = 2
-
-        val packer = NewBinPacker.MaxRectsPacker(4096, 4096, PADDING * 2, NewBinPacker.IOption(
+        val packer = NewBinPacker.MaxRectsPacker(4096, 4096, padding * 2, NewBinPacker.IOption(
             smart = true,
             pot = true,
             square = false,
             allowRotation = enableRotation,
             //allowRotation = false,
             tag = false,
-            border = PADDING
+            border = padding
         ))
 
         packer.addArray(images.map { (file, image) ->
@@ -94,7 +93,7 @@ object NewTexturePacker {
                 //println("$rect :: info=$info")
 
                 val chunk = if (rect.rot) info.trimmedImage.flipY().rotate90() else info.trimmedImage
-                out.put(rect.x - PADDING, rect.y - PADDING, chunk.extrude(PADDING))
+                out.put(rect.x - padding, rect.y - padding, chunk.extrude(padding))
                 //out.put(rect.x, rect.y, chunk)
 
                 val obj = LinkedHashMap<String, Any?>()
@@ -139,3 +138,4 @@ object NewTexturePacker {
         return outAtlases
     }
 }
+

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/processor/KorgeTexturePacker.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/processor/KorgeTexturePacker.kt
@@ -7,6 +7,7 @@ import kotlin.system.*
 
 open class KorgeTexturePacker : KorgeResourceProcessor {
     override fun processFolder(context: KorgeResourceProcessorContext) {
+        context.resourceFolders
         for (folder in context.resourceFolders) {
             val files = folder.listFiles()?.toList() ?: emptyList()
             for (file in files) {
@@ -18,9 +19,17 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
                             generate(context.logger, atlasJsonFile, arrayOf(file))
                         }
                         file.isFile -> {
-                            val sources = file.readLines().filter { it.isNotBlank() }.map { File(folder, it) }.toTypedArray()
+                            val settings = parseAtlasSettingsFile(file)
+                            val sources = settings.files.map { File(folder, it) }.toTypedArray()
                             context.skipFiles(file, *sources)
-                            generate(context.logger, atlasJsonFile, sources)
+                            generate(
+                                context.logger,
+                                atlasJsonFile,
+                                sources,
+                                enableRotation = settings.enableRotation,
+                                enableTrimming = settings.enableTrimming,
+                                padding = settings.padding,
+                            )
                         }
                     }
                 }
@@ -28,7 +37,14 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
         }
     }
 
-    fun generate(logger: org.slf4j.Logger, outputFile: File, imageFolders: Array<File>) {
+    private fun generate(
+        logger: org.slf4j.Logger,
+        outputFile: File,
+        imageFolders: Array<File>,
+        enableRotation: Boolean = true,
+        enableTrimming: Boolean = true,
+        padding: Int = 2,
+    ) {
         val involvedFiles = NewTexturePacker.getAllFiles(*imageFolders)
         //val maxLastModifiedTime = involvedFiles.maxOfOrNull { it.file.lastModified() } ?: System.currentTimeMillis()
         val involvedString = involvedFiles.map { it.relative.name + ":" + it.file.length() + ":" + it.file.lastModified() }.sorted().joinToString("\n")
@@ -37,7 +53,12 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
         //if (!outputFile.exists() || involvedFile.takeIfExists()?.readText() != involvedString) {
         if (involvedFile.takeIfExists()?.readText() != involvedString) {
             val time = measureTimeMillis {
-                val results = NewTexturePacker.packImages(*imageFolders, enableRotation = true, enableTrimming = true)
+                val results = NewTexturePacker.packImages(
+                    *imageFolders,
+                    enableRotation = enableRotation,
+                    enableTrimming = enableTrimming,
+                    padding = padding
+                )
                 for (result in results) {
                     val imageOut = result.write(outputFile)
                 }
@@ -50,4 +71,63 @@ open class KorgeTexturePacker : KorgeResourceProcessor {
             logger.info("KorgeTexturePacker.CACHED: $involvedFile")
         }
     }
+
+    private fun parseAtlasSettingsFile(atlasFile: File): AtlasGenerationSettings {
+        var enableRotation = true
+        var enableTrimming = true
+        var padding = 2
+        val files = mutableListOf<String>()
+
+        atlasFile.forEachLine { line ->
+            val trimmedLine = line.trim()
+            if (trimmedLine.isBlank()) return@forEachLine
+
+            val enableRotationSetting = tryExtractSetting(trimmedLine, "#enable-rotation") { it.toBoolean() }
+            if (enableRotationSetting != null) {
+                enableRotation = enableRotationSetting
+                return@forEachLine
+            }
+
+            val enableTrimmingSetting = tryExtractSetting(trimmedLine, "#enable-trimming") { it.toBoolean() }
+            if (enableTrimmingSetting != null) {
+                enableTrimming = enableTrimmingSetting
+                return@forEachLine
+            }
+
+            val paddingSetting = tryExtractSetting(trimmedLine, "#padding") { it.toInt() }
+            if (paddingSetting != null) {
+                padding = paddingSetting
+                return@forEachLine
+            }
+
+            files.add(trimmedLine)
+        }
+
+        return AtlasGenerationSettings(
+            files = files,
+            enableRotation = enableRotation,
+            enableTrimming = enableTrimming,
+            padding = padding,
+        )
+    }
+
+    private inline fun <T> tryExtractSetting(line: String, key: String, valueParser: (String) -> T): T? {
+        return if (line.startsWith(key)) {
+            try {
+                val value = line.substringAfter("=").trim()
+                valueParser(value)
+            } catch (e: Exception) {
+                null
+            }
+        } else {
+            null
+        }
+    }
 }
+
+private data class AtlasGenerationSettings(
+    val files: List<String>,
+    val enableRotation: Boolean,
+    val enableTrimming: Boolean,
+    val padding: Int,
+)

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/texpacker/NewTexturePacker.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/texpacker/NewTexturePacker.kt
@@ -44,6 +44,7 @@ object NewTexturePacker {
         vararg folders: File,
         enableRotation: Boolean = true,
         enableTrimming: Boolean = true,
+        padding: Int = 2,
     ): List<AtlasInfo> {
         val images: List<Pair<File, SimpleBitmap>> = getAllFiles(*folders).mapNotNull {
             try {
@@ -54,16 +55,14 @@ object NewTexturePacker {
             }
         }
 
-        val PADDING = 2
-
-        val packer = NewBinPacker.MaxRectsPacker(4096, 4096, PADDING * 2, NewBinPacker.IOption(
+        val packer = NewBinPacker.MaxRectsPacker(4096, 4096, padding * 2, NewBinPacker.IOption(
             smart = true,
             pot = true,
             square = false,
             allowRotation = enableRotation,
             //allowRotation = false,
             tag = false,
-            border = PADDING
+            border = padding
         ))
 
         packer.addArray(images.map { (file, image) ->
@@ -94,7 +93,7 @@ object NewTexturePacker {
                 //println("$rect :: info=$info")
 
                 val chunk = if (rect.rot) info.trimmedImage.flipY().rotate90() else info.trimmedImage
-                out.put(rect.x - PADDING, rect.y - PADDING, chunk.extrude(PADDING))
+                out.put(rect.x - padding, rect.y - padding, chunk.extrude(padding))
                 //out.put(rect.x, rect.y, chunk)
 
                 val obj = LinkedHashMap<String, Any?>()


### PR DESCRIPTION
Autogenerated atlas texture packing in this pr can be configured through .atlas file in the following manner:
```
#enable-rotation=false
#enable-trimming=false
#padding=1
folder1
folder2
```