### PR TITLE
Fix centering calculations using scaledHeight

### DIFF
--- a/korge/src/korlibs/korge/view/align/ViewAlignExt.kt
+++ b/korge/src/korlibs/korge/view/align/ViewAlignExt.kt
@@ -5,7 +5,7 @@ import korlibs.korge.view.*
 
 /** Chainable method returning this that sets [this] View in the middle between [x1] and [x2] */
 fun <T : View> T.centerXBetween(x1: Double, x2: Double): T {
-    this.x = (x2 + x1 - this.scaledHeight) / 2
+    this.x = (x2 + x1 - this.scaledWidth) / 2
     return this
 }
 fun <T : View> T.centerXBetween(x1: Float, x2: Float): T = centerXBetween(x1.toDouble(), x2.toDouble())

--- a/korge/src/korlibs/korge/view/align/ViewAlignExt.kt
+++ b/korge/src/korlibs/korge/view/align/ViewAlignExt.kt
@@ -5,7 +5,7 @@ import korlibs.korge.view.*
 
 /** Chainable method returning this that sets [this] View in the middle between [x1] and [x2] */
 fun <T : View> T.centerXBetween(x1: Double, x2: Double): T {
-    this.x = (x2 + x1 - this.width) / 2
+    this.x = (x2 + x1 - this.scaledHeight) / 2
     return this
 }
 fun <T : View> T.centerXBetween(x1: Float, x2: Float): T = centerXBetween(x1.toDouble(), x2.toDouble())
@@ -13,7 +13,7 @@ fun <T : View> T.centerXBetween(x1: Int, x2: Int): T = centerXBetween(x1.toDoubl
 
 /** Chainable method returning this that sets [this] View in the middle between [y1] and [y2] */
 fun <T : View> T.centerYBetween(y1: Double, y2: Double): T {
-    this.y = (y2 + y1 - this.height) / 2
+    this.y = (y2 + y1 - this.scaledHeight) / 2
     return this
 }
 fun <T : View> T.centerYBetween(y1: Float, y2: Float): T = centerYBetween(y1.toDouble(), y2.toDouble())


### PR DESCRIPTION
Any reason not to use scaledHeight?
```
var settings = image(resourcesVfs["settings.svg"].readSVG().scaled(1, 1).render()) {
            zIndex(3)
            position(10, offsetY / 2)

            scale(0.2)
        }
        println("SETTINGS HEIGHT: ${settings.height}") // 400 (incorrect)
        println("SETTINGS HEIGHT: ${settings.scaledHeight}") // 80 (correct)
        settings.centerYBetween(offsetY, 0.0) // -197 or smth
```

`centerYBetween` does ` - height` (minus) and then here in the snippet it will center the `viewY` on -197



BTW: If this gets merged, the same applies to animators (scaleTo()) too. 