### PR TITLE
Update to Korlibs v6.1.0 and Kotlin 2.3.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,11 @@
 import korlibs.root.*
-import org.jetbrains.kotlin.backend.common.serialization.*
-import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
     //id "com.dorongold.task-tree" version "2.1.1"
     // ./gradlew :kds:compileKotlinJs taskTree
 }
 
-korlibs.root.RootKorlibsPlugin.doInit(rootProject)
+RootKorlibsPlugin.doInit(rootProject)
 
 // Used to verify we are publishing with iOS references even if we do the publishing from another machine like windows or linux
 tasks {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -81,7 +81,13 @@ if (System.getenv("FORCED_VERSION") != null) {
             .directory(rootDir)
             .redirectErrorStream(true)
             .start()
-        gitVersion = process.inputStream.bufferedReader().readText().trim()
+        val describeOutput = process.inputStream.bufferedReader().readText().trim()
+        val exitCode = process.waitFor()
+        val describePattern = Regex("""^.+-dirty$""")
+        val hasExpectedGitSections = describePattern.matches(describeOutput)
+        if (exitCode == 0 && describeOutput.isNotBlank() && hasExpectedGitSections) {
+            gitVersion = describeOutput
+        }
     } catch (e: Throwable) {
         System.err.println(e.message)
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
-
 import org.jetbrains.kotlin.gradle.tasks.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.StringReader
 import java.util.*
 
@@ -50,13 +50,10 @@ repositories {
     maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
 }
 
-tasks.withType(KotlinCompile::class).all {
-    kotlinOptions.suppressWarnings = true
-}
-
 tasks.withType(KotlinCompile::class).configureEach {
-    kotlinOptions {
-        jvmTarget = "11"
+    compilerOptions {
+        suppressWarnings.set(true)
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 
@@ -80,11 +77,11 @@ try {
 
 if (System.getenv("FORCED_VERSION") != null) {
     try {
-        gitVersion = Runtime.getRuntime().exec(
-            "git describe --abbrev=8 --tags --dirty",
-            arrayOf(),
-            rootDir
-        ).inputStream.readBytes().toString().trim()
+        val process = ProcessBuilder("git", "describe", "--abbrev=8", "--tags", "--dirty")
+            .directory(rootDir)
+            .redirectErrorStream(true)
+            .start()
+        gitVersion = process.inputStream.bufferedReader().readText().trim()
     } catch (e: Throwable) {
         System.err.println(e.message)
     }

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/KorgeExtension.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/KorgeExtension.kt
@@ -681,12 +681,11 @@ open class KorgeExtension(
 	fun dependencyCInterops(name: String, targets: List<String>) = project {
 		cinterops += CInteropTargets(name, targets)
 		for (target in targets) {
-			((kotlin.targets.findByName(target) as AbstractKotlinTarget).compilations["main"] as KotlinNativeCompilation).apply {
-				cinterops.apply {
-					maybeCreate(name).apply {
-					}
-				}
-			}
+			val nativeTarget = kotlin.targets.findByName(target) as? KotlinNativeTarget
+				?: error("Target '$target' is not a Kotlin/Native target")
+			val mainCompilation = nativeTarget.compilations.findByName("main") as? KotlinNativeCompilation
+				?: error("Target '$target' has no 'main' native compilation")
+			mainCompilation.cinterops.maybeCreate(name)
 		}
 	}
 

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/generate/TemplateGenerator.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/generate/TemplateGenerator.kt
@@ -76,7 +76,7 @@ object TemplateGenerator {
     }
 
     fun String.replaceTemplate(kind: String): String {
-        val lkind = kind.toLowerCase()
+        val lkind = kind.lowercase()
         return this
             .replace("FastArrayList", "ArrayList")
             .replace("arrayOfNulls<Any>", "${kind}Array")

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
@@ -62,15 +62,15 @@ fun Project.configureAndroidDirect(projectType: ProjectType, isKorge: Boolean) {
     //val generated = AndroidGenerated(korge)
 
     dependencies {
-        if (SemVer(BuildVersions.KOTLIN) >= SemVer("1.9.0")) {
+        if (SemVer(BuildVersions.KOTLIN) >= SemVer("2.3.20")) {
             add("androidUnitTestImplementation", "org.jetbrains.kotlin:kotlin-test")
         }
         add("androidTestImplementation", "org.jetbrains.kotlin:kotlin-test")
 
         add("androidTestImplementation", "org.jetbrains.kotlin:kotlin-test")
-        add("androidTestImplementation", "androidx.test:core:1.4.0")
-        add("androidTestImplementation", "androidx.test.ext:junit:1.1.2")
-        add("androidTestImplementation", "androidx.test.espresso:espresso-core:3.3.0")
+        add("androidTestImplementation", "androidx.test:core:1.7.0")
+        add("androidTestImplementation", "androidx.test.ext:junit:1.3.0")
+        add("androidTestImplementation", "androidx.test.espresso:espresso-core:3.7.0")
         //androidTestImplementation 'com.android.support.test:runner:1.0.2'
     }
 

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.korge.gradle.targets.android
 
 import com.android.build.api.dsl.*
@@ -13,6 +15,8 @@ import korlibs.korge.gradle.util.*
 import org.gradle.api.*
 import org.gradle.api.tasks.*
 import org.gradle.configurationcache.extensions.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import java.io.*
 
 fun Project.configureAndroidDirect(projectType: ProjectType, isKorge: Boolean) {
@@ -38,7 +42,11 @@ fun Project.configureAndroidDirect(projectType: ProjectType, isKorge: Boolean) {
         publishLibraryVariantsGroupedByFlavor = true
         //this.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
         compilations.allThis {
-            kotlinOptions.jvmTarget = ANDROID_JAVA_VERSION_STR
+            compileTaskProvider.configure {
+                (it as KotlinJvmCompile).compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(ANDROID_JAVA_VERSION_STR))
+                }
+            }
         }
         AddFreeCompilerArgs.addFreeCompilerArgs(project, this)
     }

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/js/Esbuild.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/js/Esbuild.kt
@@ -31,7 +31,7 @@ fun Project.configureErrorableEsbuild() {
 
     val env by lazy { org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.apply(project.rootProject).requireConfigured() }
     val ENV_PATH by lazy {
-        val NODE_PATH = File(env.nodeExecutable).parent
+        val NODE_PATH = File(env.executable).parent
         val PATH_SEPARATOR = File.pathSeparator
         val OLD_PATH = System.getenv("PATH")
         "$NODE_PATH$PATH_SEPARATOR$OLD_PATH"
@@ -45,7 +45,7 @@ fun Project.configureErrorableEsbuild() {
         doFirst {
             //val nodeDir = env.nodeBinDir
             val nodeDir = env.dir
-            val file1: File = File(env.nodeExecutable)
+            val file1: File = File(env.executable)
             val file2: File? = File(nodeDir, "lib/node_modules/npm/bin/npm-cli.js").takeIf { it.exists() }
             val file3: File? = File(nodeDir, "node_modules/npm/bin/npm-cli.js").takeIf { it.exists() }
             val npmCmd = arrayOf<File>(

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/js/JavaScript.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/js/JavaScript.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.korge.gradle.targets.js
 
 import korlibs.korge.gradle.*
@@ -13,6 +15,7 @@ import org.gradle.api.file.*
 import org.gradle.api.tasks.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 import java.io.*
 
 private object JavaScriptClass
@@ -38,12 +41,7 @@ fun Project.configureJavaScript(projectType: ProjectType) {
             this.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.js)
 
 			compilations.allThis {
-				kotlinOptions.apply {
-					sourceMap = korge.sourceMaps
-					//metaInfo = true
-					//moduleKind = "umd"
-					suppressWarnings = korge.supressWarnings
-				}
+                // Handled below for all JS compile tasks
 			}
             configureJsTargetOnce()
             configureJSTestsOnce()
@@ -57,8 +55,9 @@ fun Project.configureJavaScript(projectType: ProjectType) {
 	}
 
     // https://youtrack.jetbrains.com/issue/KT-58187/KJS-IR-Huge-performance-bottleneck-while-generating-sourceMaps-getCannonicalFile#focus=Comments-27-7301819.0-0
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile> {
+    tasks.withType(Kotlin2JsCompile::class.java).allThis {
         kotlinOptions.sourceMap = korge.sourceMaps
+        kotlinOptions.suppressWarnings = korge.supressWarnings
     }
 
     val generatedIndexHtmlDir = File(project.buildDir, "processedResources-www")
@@ -147,7 +146,7 @@ abstract class JsCreateIndexTask : DefaultTask() {
         //println("resourcesFolders: $resourcesFolders")
         fun readTextFile(name: String): String {
             for (folder in resourcesFolders) {
-                val file = File(folder, name)?.takeIf { it.exists() } ?: continue
+                val file = File(folder, name).takeIf { it.exists() } ?: continue
                 return file.readText()
             }
             return JavaScriptClass::class.java.classLoader.getResourceAsStream(name)?.readBytes()?.toString(Charsets.UTF_8)

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/jvm/Jvm.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/jvm/Jvm.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.korge.gradle.targets.jvm
 
 import korlibs.*

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/native/KotlinNativeCrossTest.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/native/KotlinNativeCrossTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.korge.gradle.targets.native
 
 import korlibs.korge.gradle.targets.*

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/native/NativeExt.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/native/NativeExt.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.*
 import org.jetbrains.kotlin.gradle.tasks.*
 
 fun KotlinNativeCompilation.getLinkTask(kind: NativeOutputKind, type: NativeBuildType, project: Project): KotlinNativeLink {
-	val taskName = "link${type.name.toLowerCase().capitalize()}${kind.name.toLowerCase().capitalize()}${target.name.capitalize()}"
+	val taskName = "link${type.name.lowercase().capitalize()}${kind.name.lowercase().capitalize()}${target.name.capitalize()}"
     val taskName2 = "link${target.name.capitalize()}"
 
 	val tasks = listOf(

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/wasm/ConfigureWasm.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/targets/wasm/ConfigureWasm.kt
@@ -1,3 +1,8 @@
+@file:OptIn(
+    org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class,
+    org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalDistributionDsl::class
+)
+
 package korlibs.korge.gradle.targets.wasm
 
 import korlibs.*
@@ -14,7 +19,6 @@ fun Project.configureWasmTarget(executable: Boolean, binaryen: Boolean = false) 
             if (executable) {
                 binaries.executable()
             }
-            //applyBinaryen()
             browser {
                 //commonWebpackConfig { experiments = mutableSetOf("topLevelAwait") }
                 if (executable) {
@@ -29,7 +33,11 @@ fun Project.configureWasmTarget(executable: Boolean, binaryen: Boolean = false) 
                 //}
             }
 
-            if (binaryen) applyBinaryen()
+            // Binaryen is enabled by default in recent Kotlin versions.
+            // Keeping the flag for API compatibility, but no explicit call is required.
+            if (binaryen) {
+                // no-op
+            }
         }
 
         sourceSets.maybeCreate("wasmJsTest").apply {

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/Dyn.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/Dyn.kt
@@ -304,7 +304,7 @@ inline class Dyn(val value: Any?) : Comparable<Dyn> {
     fun toChar(): Char = when {
         value is Char -> value
         value is String && (value.length == 1) -> value.first()
-        else -> toNumber().toChar()
+        else -> toNumber().toInt().toChar()
     }
 
     fun toShort(): Short = toNumber().toShort()

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/Dyn.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/Dyn.kt
@@ -265,7 +265,7 @@ inline class Dyn(val value: Any?) : Comparable<Dyn> {
         is Number -> toDouble() != 0.0
         is String -> {
             if (extraStrings) {
-                when (value.toLowerCase()) {
+                when (value.lowercase()) {
                     "", "0", "false", "NaN", "null", "undefined", "ko", "no" -> false
                     else -> true
                 }

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/Hex.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/Hex.kt
@@ -2,8 +2,8 @@ package korlibs.korge.gradle.util
 
 object Hex {
 	private const val DIGITS = "0123456789ABCDEF"
-	val DIGITS_UPPER = DIGITS.toUpperCase()
-	val DIGITS_LOWER = DIGITS.toLowerCase()
+	val DIGITS_UPPER = DIGITS.uppercase()
+	val DIGITS_LOWER = DIGITS.lowercase()
 
 	fun decodeChar(c: Char): Int = when (c) {
 		in '0'..'9' -> c - '0'

--- a/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
+++ b/buildSrc/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
@@ -166,7 +166,7 @@ fun HttpExchange.respond(content: RangedContent, headers: List<Pair<String, Stri
     }
 }
 
-fun File.miniMimeType() = when (this.extension.toLowerCase()) {
+fun File.miniMimeType() = when (this.extension.lowercase()) {
     "htm", "html" -> "text/html"
     "css" -> "text/css"
     "txt" -> "text/plain"

--- a/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
+++ b/buildSrc/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.root
 
 import korlibs.*
@@ -26,6 +28,7 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.mocha.*
 import org.jetbrains.kotlin.gradle.tasks.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.*
 import java.nio.file.*
 import kotlin.io.path.*
@@ -183,7 +186,8 @@ object RootKorlibsPlugin {
     }
 
     fun Project.initPlugins() {
-        plugins.apply("java")
+        // java-base keeps lifecycle tasks without conflicting with kotlin-multiplatform
+        plugins.apply("java-base")
         plugins.apply("kotlin-multiplatform")
         plugins.apply("signing")
         plugins.apply("maven-publish")
@@ -277,7 +281,12 @@ object RootKorlibsPlugin {
                     }
                     jvm {
                         compilations.allThis {
-                            kotlinOptions.jvmTarget = GRADLE_JAVA_VERSION_STR
+                            compileTaskProvider.configure {
+                                (it as org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile)
+                                    .compilerOptions
+                                    .jvmTarget
+                                    .set(JvmTarget.fromTarget(GRADLE_JAVA_VERSION_STR))
+                            }
                             //kotlinOptions.freeCompilerArgs.add("-Xno-param-assertions")
                             //kotlinOptions.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jackson = "2.16.1"
-jna = "5.13.0"
+jna = "5.18.1"
 jcodec = "0.2.5"
 junit = "4.13.2"
 proguard-gradle = "7.2.2"
@@ -9,11 +9,12 @@ proguard-gradle = "7.2.2"
 asm = "9.5"
 jgit = "5.13.1.202206130422-r"
 
-kotlin = "2.0.20"
+korlibs = "6.1.0"
+kotlin = "2.3.20"
 #kotlinx-coroutines = "1.8.1"
-kotlinx-coroutines = "1.9.0-RC.2"
+kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.7.1"
-kotlinx-atomicfu = "0.24.0"
+kotlinx-atomicfu = "0.32.1"
 
 kotlinx-benchmark = "0.4.7"
 dokka = "1.9.20"
@@ -25,17 +26,18 @@ gson = "2.10.1"
 gradle-publish-plugin = "1.2.1"
 # https://repo.maven.apache.org/maven2/org/jetbrains/intellij/deps/intellij-coverage-agent/
 
+
 [libraries]
-korlibs-audio = { module = "com.soywiz:korlibs-audio", version = "6.0.0" }
-korlibs-image = { module = "com.soywiz:korlibs-image", version = "6.0.0" }
-korlibs-inject = { module = "com.soywiz:korlibs-inject", version = "6.0.0" }
-korlibs-template = { module = "com.soywiz:korlibs-template", version = "6.0.0" }
-korlibs-time = { module = "com.soywiz:korlibs-time", version = "6.0.0" }
-korlibs-serialization = { module = "com.soywiz:korlibs-serialization", version = "6.0.0" }
-korlibs-datastructure = { module = "com.soywiz:korlibs-datastructure", version = "6.0.0" }
-korlibs-datastructure-core = { module = "com.soywiz:korlibs-datastructure-core", version = "6.0.0" }
-korlibs-memory = { module = "com.soywiz:korlibs-memory", version = "6.0.0" }
-korlibs-io-stream = { module = "com.soywiz:korlibs-io-stream", version = "6.0.0" }
+korlibs-audio = { module = "org.korge:korlibs-audio", version.ref = "korlibs" }
+korlibs-image = { module = "org.korge:korlibs-image", version.ref = "korlibs" }
+korlibs-inject = { module = "org.korge:korlibs-inject", version.ref = "korlibs" }
+korlibs-template = { module = "org.korge:korlibs-template", version.ref = "korlibs" }
+korlibs-time = { module = "org.korge:korlibs-time", version.ref = "korlibs" }
+korlibs-serialization = { module = "org.korge:korlibs-serialization", version.ref = "korlibs" }
+korlibs-datastructure = { module = "org.korge:korlibs-datastructure", version.ref = "korlibs" }
+korlibs-datastructure-core = { module = "org.korge:korlibs-datastructure-core", version.ref = "korlibs" }
+korlibs-memory = { module = "org.korge:korlibs-memory", version.ref = "korlibs" }
+korlibs-io-stream = { module = "org.korge:korlibs-io-stream", version.ref = "korlibs" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jackson = "2.16.1"
+jackson = "2.21.2"
 jna = "5.18.1"
 jcodec = "0.2.5"
 junit = "4.13.2"
@@ -10,7 +10,7 @@ asm = "9.5"
 jgit = "5.13.1.202206130422-r"
 
 korlibs = "6.1.0"
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 #kotlinx-coroutines = "1.8.1"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.7.1"
@@ -19,11 +19,11 @@ kotlinx-atomicfu = "0.32.1"
 kotlinx-benchmark = "0.4.7"
 dokka = "1.9.20"
 kover = "0.6.1"
-kover-agent = "1.0.761"
+kover-agent = "1.0.775"
 node = "20.12.1"
 android-build-gradle = "8.2.2"
-gson = "2.10.1"
-gradle-publish-plugin = "1.2.1"
+gson = "2.14.0"
+gradle-publish-plugin = "2.1.1"
 # https://repo.maven.apache.org/maven2/org/jetbrains/intellij/deps/intellij-coverage-agent/
 
 

--- a/korge-core/src/korlibs/graphics/gl/AGOpengl.kt
+++ b/korge-core/src/korlibs/graphics/gl/AGOpengl.kt
@@ -123,8 +123,15 @@ class AGOpengl(val gl: KmlGl, var context: KmlGlContext? = null) : AG() {
             logger.info { "gl.versionInt=${gl.versionInt}" }
         }
 
-        val nprogram: GLBaseProgram = map.getOrPut(program) {
-            GLBaseProgram(glGlobalState, GLShaderCompiler.programCreate(gl, this.glslConfig, program, debugName = program.name)).also { baseProgram ->
+        var nprogram: GLBaseProgram? = map[program]
+        if (nprogram != null && nprogram.programInfo.usedUniformBlocks && !gl.isUniformBuffersSupported) {
+            // Rebuild with non-UBO shaders if runtime capability probes downgraded support.
+            nprogram.delete()
+            map.remove(program)
+            nprogram = null
+        }
+        if (nprogram == null) {
+            nprogram = GLBaseProgram(glGlobalState, GLShaderCompiler.programCreate(gl, this.glslConfig, program, debugName = program.name)).also { baseProgram ->
                 baseProgram.use()
 
                 val programInfo = baseProgram.programInfo
@@ -135,19 +142,23 @@ class AGOpengl(val gl: KmlGl, var context: KmlGlContext? = null) : AG() {
                     gl.uniform1i(location, it.index)
                 }
 
-                if (programInfo.config.useUniformBlocks) {
+                if (gl.isUniformBuffersSupported && programInfo.usedUniformBlocks) {
                     program.uniformBlocks.fastForEach {
                         val index = gl.getUniformBlockIndex(programId, it.name)
-                        gl.uniformBlockBinding(programId, index, it.fixedLocation)
+                        if (index >= 0) {
+                            gl.uniformBlockBinding(programId, index, it.fixedLocation)
+                        }
                     }
                 }
             }
+            map[program] = nprogram
         }
         //nprogram.agProgram._native = nprogram.
         //nprogram.
-        if (currentProgram != nprogram) {
-            currentProgram = nprogram
-            nprogram.use()
+        val activeProgram = nprogram ?: error("Program should have been created for ${program.name}")
+        if (currentProgram != activeProgram) {
+            currentProgram = activeProgram
+            activeProgram.use()
         }
     }
 
@@ -624,8 +635,7 @@ class AGOpengl(val gl: KmlGl, var context: KmlGlContext? = null) : AG() {
 
         val glProgramInfo = glProgram.programInfo
         uniformBlocks.fastForEachBlock { index, block, buffer, valueIndex ->
-            //if (gl.isUniformBuffersSupported && glProgram.programInfo.config.useUniformBlocks) {
-            if (glProgram.programInfo.config.useUniformBlocks) {
+            if (gl.isUniformBuffersSupported && glProgram.programInfo.usedUniformBlocks) {
                 //println("isUniformBuffersSupported!!")
                 val buffer = bindBuffer(buffer, AGBufferKind.UNIFORM)
                 gl.bindBufferRange(KmlGl.UNIFORM_BUFFER, block.block.fixedLocation, buffer?.id ?: -1, valueIndex * block.blockSize, block.blockSize)

--- a/korge-core/src/korlibs/graphics/gl/GLShaderCompiler.kt
+++ b/korge-core/src/korlibs/graphics/gl/GLShaderCompiler.kt
@@ -115,7 +115,6 @@ internal object GLShaderCompiler {
     }
 }
 
-@SharedImmutable
 val KmlGl.versionString by Extra.PropertyThis<KmlGl, String> {
     when {
         this.variant.isWebGL -> if (this.variant.version == 1) "1.00" else "3.00"
@@ -123,7 +122,6 @@ val KmlGl.versionString by Extra.PropertyThis<KmlGl, String> {
     }
 }
 
-@SharedImmutable
 val KmlGl.versionInt by Extra.PropertyThis<KmlGl, Int> {
     Regex("(\\d+\\.\\d+)").find(versionString)?.value?.replace(".", "")?.trim()?.toIntOrNull() ?: 100
 }

--- a/korge-core/src/korlibs/graphics/gl/GLShaderCompiler.kt
+++ b/korge-core/src/korlibs/graphics/gl/GLShaderCompiler.kt
@@ -7,7 +7,7 @@ import korlibs.kgl.*
 import korlibs.logger.*
 import kotlin.native.concurrent.*
 
-internal data class GLProgramInfo(var programId: Int, var vertexId: Int, var fragmentId: Int, val blocks: List<UniformBlock>, val config: GlslConfig) {
+internal data class GLProgramInfo(var programId: Int, var vertexId: Int, var fragmentId: Int, val blocks: List<UniformBlock>, val config: GlslConfig, val usedUniformBlocks: Boolean) {
     private val blocksByFixedLocation = blocks.associateBy { it.fixedLocation }
     private val maxBlockId = (blocks.maxOfOrNull { it.fixedLocation } ?: -1) + 1
     val uniforms: Array<UniformsRef?> = Array(maxBlockId + 1) { blocksByFixedLocation[it]?.let { UniformsRef(it) } }
@@ -72,7 +72,7 @@ internal object GLShaderCompiler {
         gl.attachShader(id, vertexShaderId)
         gl.linkProgram(id)
         val linkStatus = gl.getProgramiv(id, gl.LINK_STATUS)
-        return GLProgramInfo(id, vertexShaderId, fragmentShaderId, program.uniformBlocks, finalConfig)
+        return GLProgramInfo(id, vertexShaderId, fragmentShaderId, program.uniformBlocks, finalConfig, finalConfig.useUniformBlocks)
     }
 
     fun createShaderWithConfigs(gl: KmlGl, program: Program, debugName: String?, configs: List<GlslConfig>): Triple<Int, Int, GlslConfig> {

--- a/korge-core/src/korlibs/korge/logger/LoggerExt.kt
+++ b/korge-core/src/korlibs/korge/logger/LoggerExt.kt
@@ -18,7 +18,7 @@ fun configureLoggerFromProperties(str: String) {
 	val props = Props.load(str)
 	for ((key, value) in props) {
 		try {
-			Logger(key).level = Logger.Level.valueOf(value.toUpperCase())
+			Logger(key).level = Logger.Level.valueOf(value.uppercase())
 		} catch (e: Throwable) {
 			e.printStackTrace()
 		}

--- a/korge-core/src/korlibs/korge/render/BatchBuilder2D.kt
+++ b/korge-core/src/korlibs/korge/render/BatchBuilder2D.kt
@@ -19,7 +19,6 @@ import kotlin.jvm.*
 import kotlin.math.*
 import kotlin.native.concurrent.*
 
-@SharedImmutable
 private val logger = Logger("BatchBuilder2D")
 
 /**

--- a/korge-core/src/korlibs/korge/render/RenderContext2D.kt
+++ b/korge-core/src/korlibs/korge/render/RenderContext2D.kt
@@ -13,7 +13,6 @@ import korlibs.math.geom.shape.*
 import korlibs.math.geom.vector.*
 import kotlin.native.concurrent.*
 
-@SharedImmutable
 private val logger = Logger("RenderContext2D")
 
 /**

--- a/korge-core/src/korlibs/korge/render/TexturedVertexArray.kt
+++ b/korge-core/src/korlibs/korge/render/TexturedVertexArray.kt
@@ -301,7 +301,6 @@ private fun IntArray.repeat(count: Int): IntArray {
 
 @PublishedApi internal const val TEXTURED_ARRAY_COMPONENTS_PER_VERTEX = 6
 @KorgeInternal
-@SharedImmutable
 @PublishedApi internal val TEXTURED_ARRAY_QUAD_INDICES = shortArrayOf(0, 1, 2,  3, 0, 2)
 @PublishedApi internal val TEXTURED_ARRAY_EMPTY_INT_ARRAY = IntArray(0)
 @PublishedApi internal val TEXTURED_ARRAY_EMPTY_SHORT_ARRAY = ShortArray(0)

--- a/korge-core/src@jvm/korlibs/korge/resources/ResourceProcessor.kt
+++ b/korge-core/src@jvm/korlibs/korge/resources/ResourceProcessor.kt
@@ -22,7 +22,7 @@ abstract class ResourceProcessor @JvmOverloads constructor(
 
 	val BINARY_ROOT by lazy { runBlocking { localVfs(System.getProperty("user.home"))[".korge"].apply { mkdir() }.jail() } }
 
-	val extensionLCs = extensions.toList().map(String::toLowerCase)
+	val extensionLCs = extensions.toList().map(String::lowercase)
 	protected abstract suspend fun processInternal(inputFile: VfsFile, outputFile: VfsFile): Unit
 
 	suspend fun requireRegeneration(file: VfsFile, outputFolder: VfsFile): Boolean {

--- a/korge-core/src@jvm/korlibs/render/osx/Cocoa.kt
+++ b/korge-core/src@jvm/korlibs/render/osx/Cocoa.kt
@@ -68,7 +68,7 @@ class CGFloat(val value: Double) : Number(), NativeMapped {
     }
 
     override fun toByte(): Byte = value.toInt().toByte()
-    override fun toChar(): Char = value.toChar()
+    override fun toChar(): Char = value.toInt().toChar()
     override fun toDouble(): Double = value.toDouble()
     override fun toFloat(): Float = value.toFloat()
     override fun toInt(): Int = value.toInt()
@@ -985,7 +985,7 @@ open class NSObject(val id: Long) : IntegerType(8, id, false), NativeMapped {
     }
 
     override fun toByte(): Byte = id.toByte()
-    override fun toChar(): Char = id.toChar()
+    override fun toChar(): Char = id.toInt().toChar()
     override fun toShort(): Short = id.toShort()
     override fun toInt(): Int = id.toInt()
     override fun toLong(): Long = id

--- a/korge-core/src@jvm/korlibs/render/platform/INativeGL.kt
+++ b/korge-core/src@jvm/korlibs/render/platform/INativeGL.kt
@@ -283,7 +283,7 @@ object DirectGL : INativeGL {
     }
 }
 
-private val arch by lazy { System.getProperty("os.arch").toLowerCase() }
+private val arch by lazy { System.getProperty("os.arch").lowercase() }
 
 val nativeOpenGLLibraryPath: String by lazy {
     Environment["OPENGL_LIB_PATH"]?.let { path ->

--- a/korge-core/src@jvm/korlibs/render/platform/NativeKgl.kt
+++ b/korge-core/src@jvm/korlibs/render/platform/NativeKgl.kt
@@ -12,6 +12,7 @@ import java.nio.IntBuffer
 
 open class NativeKgl constructor(private val gl: INativeGL) : KmlGl() {
     override val variant: GLVariant = GLVariant.JVM
+    private var uniformBuffersKnownUnsupported: Boolean = false
 
     override fun activeTexture(texture: Int): Unit = gl.glActiveTexture(texture)
     override fun attachShader(program: Int, shader: Int): Unit = gl.glAttachShader(program, shader)
@@ -172,14 +173,64 @@ open class NativeKgl constructor(private val gl: INativeGL) : KmlGl() {
         gl.glRenderbufferStorageMultisample(target, samples, internalformat, width, height)
     }
 
-    override val isUniformBuffersSupported: Boolean get() = true
+    private val isUniformBuffersSupportedDetected: Boolean by lazy {
+        // Some CI/Xvfb Linux setups expose a GL context where UBO entry points are not available.
+        // Only enable UBOs when the context version/extensions explicitly advertise support.
+        val (major, minor) = parseOpenGlVersion(getString(KmlGl.VERSION))
+        val advertisedSupport = (major > 3 || (major == 3 && minor >= 1)) ||
+            "GL_ARB_uniform_buffer_object" in extensions ||
+            "GL_ES_VERSION_3_0" in extensions
+        advertisedSupport && probeUniformBufferEntryPoints()
+    }
+
+    private fun probeUniformBufferEntryPoints(): Boolean {
+        return try {
+            // Program 0 is invalid for real use, but enough to validate native symbol wiring.
+            gl.glGetUniformBlockIndex(0, "__korge_ubo_probe__")
+            true
+        } catch (t: Throwable) {
+            !isUnsupportedUniformBufferError(t)
+        }
+    }
+    override val isUniformBuffersSupported: Boolean get() = isUniformBuffersSupportedDetected && !uniformBuffersKnownUnsupported
 
     override fun bindBufferRange(target: Int, index: Int, buffer: Int, offset: Int, size: Int) {
-        return gl.glBindBufferRange(target, index, buffer, NativeLong(offset.toLong()), NativeLong(size.toLong()))
+        if (!isUniformBuffersSupported) return
+        try {
+            gl.glBindBufferRange(target, index, buffer, NativeLong(offset.toLong()), NativeLong(size.toLong()))
+        } catch (t: Throwable) {
+            if (isUnsupportedUniformBufferError(t)) {
+                uniformBuffersKnownUnsupported = true
+                return
+            }
+            throw t
+        }
     }
-    override fun getUniformBlockIndex(program: Int, name: String): Int = gl.glGetUniformBlockIndex(program, name)
-    override fun uniformBlockBinding(program: Int, uniformBlockIndex: Int, uniformBlockBinding: Int) =
-        gl.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding)
+    override fun getUniformBlockIndex(program: Int, name: String): Int {
+        if (!isUniformBuffersSupported) return -1
+        return try {
+            gl.glGetUniformBlockIndex(program, name)
+        } catch (t: Throwable) {
+            if (isUnsupportedUniformBufferError(t)) {
+                uniformBuffersKnownUnsupported = true
+                -1
+            } else {
+                throw t
+            }
+        }
+    }
+    override fun uniformBlockBinding(program: Int, uniformBlockIndex: Int, uniformBlockBinding: Int) {
+        if (!isUniformBuffersSupported || uniformBlockIndex < 0) return
+        try {
+            gl.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding)
+        } catch (t: Throwable) {
+            if (isUnsupportedUniformBufferError(t)) {
+                uniformBuffersKnownUnsupported = true
+                return
+            }
+            throw t
+        }
+    }
 
     override var isVertexArraysSupported: Boolean = true
 
@@ -202,5 +253,17 @@ open class NativeKgl constructor(private val gl: INativeGL) : KmlGl() {
     override fun bindVertexArray(array: Int): Unit { gl.glBindVertexArray(array) }
 }
 
+private fun parseOpenGlVersion(versionString: String): Pair<Int, Int> {
+    val match = Regex("(\\d+)\\.(\\d+)").find(versionString) ?: return 0 to 0
+    return (match.groupValues[1].toIntOrNull() ?: 0) to (match.groupValues[2].toIntOrNull() ?: 0)
+}
 
-private const val GL_NUM_EXTENSIONS = 0x821D
+private fun isUnsupportedUniformBufferError(t: Throwable): Boolean {
+    var current: Throwable? = t
+    while (current != null) {
+        if (current is UnsupportedOperationException && (current.message?.contains("uniform buffers") == true)) return true
+        current = current.cause
+    }
+    return false
+}
+

--- a/korge-gradle-plugin-common/build.gradle.kts
+++ b/korge-gradle-plugin-common/build.gradle.kts
@@ -31,10 +31,10 @@ java {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions {
-        jvmTarget = jversion
-        apiVersion = "1.7"
-        languageVersion = "1.7"
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
     }
 }
 

--- a/korge-gradle-plugin-common/build.gradle.kts
+++ b/korge-gradle-plugin-common/build.gradle.kts
@@ -33,8 +33,8 @@ java {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
     }
 }
 

--- a/korge-gradle-plugin-common/src/main/kotlin/com/soywiz/kproject/internal/Dyn.kt
+++ b/korge-gradle-plugin-common/src/main/kotlin/com/soywiz/kproject/internal/Dyn.kt
@@ -270,7 +270,7 @@ inline class Dyn(val value: Any?) : Comparable<Dyn> {
         is Number -> toDouble() != 0.0
         is String -> {
             if (extraStrings) {
-                when (value.toLowerCase()) {
+                when (value.lowercase()) {
                     "", "0", "false", "NaN", "null", "undefined", "ko", "no" -> false
                     else -> true
                 }

--- a/korge-gradle-plugin-settings/build.gradle.kts
+++ b/korge-gradle-plugin-settings/build.gradle.kts
@@ -21,8 +21,8 @@ java {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
     }
 }
 

--- a/korge-gradle-plugin-settings/build.gradle.kts
+++ b/korge-gradle-plugin-settings/build.gradle.kts
@@ -19,10 +19,10 @@ java {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions {
-        jvmTarget = jversion
-        apiVersion = "1.7"
-        languageVersion = "1.7"
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
     }
 }
 

--- a/korge-gradle-plugin/build.gradle.kts
+++ b/korge-gradle-plugin/build.gradle.kts
@@ -85,10 +85,11 @@ java {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions {
-        jvmTarget = jversion
-        apiVersion = "1.7"
-        languageVersion = "1.7"
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        suppressWarnings.set(true)
     }
 }
 
@@ -120,9 +121,6 @@ dependencies {
     //implementation(project(":korge-reload-agent"))
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).configureEach {
-    kotlinOptions.suppressWarnings = true
-}
 
 //def publishAllPublications = false
 

--- a/korge-gradle-plugin/build.gradle.kts
+++ b/korge-gradle-plugin/build.gradle.kts
@@ -87,8 +87,8 @@ java {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("1.7"))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
         suppressWarnings.set(true)
     }
 }

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/kproject/KProjectPlugin.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/kproject/KProjectPlugin.kt
@@ -54,7 +54,12 @@ class KProjectPlugin : Plugin<Project> {
             if (hasTarget(KProjectTarget.JVM)) {
                 jvm().apply {
                     compilations.all {
-                        it.kotlinOptions.jvmTarget = jvmVersion
+                        it.compileTaskProvider.configure { task ->
+                            (task as org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile)
+                                .compilerOptions
+                                .jvmTarget
+                                .set(JvmTarget.fromTarget(jvmVersion))
+                        }
                     }
                     //withJava()
                     testRuns.maybeCreate("test").executionTask.configure {
@@ -66,7 +71,12 @@ class KProjectPlugin : Plugin<Project> {
                 project.plugins.applyOnce("com.android.library")
                 androidTarget().apply {
                     compilations.all {
-                        it.kotlinOptions.jvmTarget = androidJvmVersion
+                        it.compileTaskProvider.configure { task ->
+                            (task as org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile)
+                                .compilerOptions
+                                .jvmTarget
+                                .set(JvmTarget.fromTarget(androidJvmVersion))
+                        }
                     }
                 }
                 project.afterEvaluate {

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/KorgeExtension.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/KorgeExtension.kt
@@ -681,12 +681,11 @@ open class KorgeExtension(
 	fun dependencyCInterops(name: String, targets: List<String>) = project {
 		cinterops += CInteropTargets(name, targets)
 		for (target in targets) {
-			((kotlin.targets.findByName(target) as AbstractKotlinTarget).compilations["main"] as KotlinNativeCompilation).apply {
-				cinterops.apply {
-					maybeCreate(name).apply {
-					}
-				}
-			}
+      val nativeTarget = kotlin.targets.findByName(target) as? KotlinNativeTarget
+        ?: error("Target '$target' is not a Kotlin/Native target")
+      val mainCompilation = nativeTarget.compilations.findByName("main") as? KotlinNativeCompilation
+        ?: error("Target '$target' has no 'main' native compilation")
+      mainCompilation.cinterops.maybeCreate(name)
 		}
 	}
 

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/generate/TemplateGenerator.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/generate/TemplateGenerator.kt
@@ -76,7 +76,7 @@ object TemplateGenerator {
     }
 
     fun String.replaceTemplate(kind: String): String {
-        val lkind = kind.toLowerCase()
+        val lkind = kind.lowercase()
         return this
             .replace("FastArrayList", "ArrayList")
             .replace("arrayOfNulls<Any>", "${kind}Array")

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
@@ -13,6 +13,8 @@ import korlibs.korge.gradle.util.*
 import org.gradle.api.*
 import org.gradle.api.tasks.*
 import org.gradle.configurationcache.extensions.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import java.io.*
 
 fun Project.configureAndroidDirect(projectType: ProjectType, isKorge: Boolean) {
@@ -38,7 +40,11 @@ fun Project.configureAndroidDirect(projectType: ProjectType, isKorge: Boolean) {
         publishLibraryVariantsGroupedByFlavor = true
         //this.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
         compilations.allThis {
-            kotlinOptions.jvmTarget = ANDROID_JAVA_VERSION_STR
+            compileTaskProvider.configure {
+                (it as KotlinJvmCompile).compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(ANDROID_JAVA_VERSION_STR))
+                }
+            }
         }
         AddFreeCompilerArgs.addFreeCompilerArgs(project, this)
     }

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/android/AndroidDirect.kt
@@ -60,15 +60,15 @@ fun Project.configureAndroidDirect(projectType: ProjectType, isKorge: Boolean) {
     //val generated = AndroidGenerated(korge)
 
     dependencies {
-        if (SemVer(BuildVersions.KOTLIN) >= SemVer("1.9.0")) {
+        if (SemVer(BuildVersions.KOTLIN) >= SemVer("2.3.20")) {
             add("androidUnitTestImplementation", "org.jetbrains.kotlin:kotlin-test")
         }
         add("androidTestImplementation", "org.jetbrains.kotlin:kotlin-test")
 
         add("androidTestImplementation", "org.jetbrains.kotlin:kotlin-test")
-        add("androidTestImplementation", "androidx.test:core:1.4.0")
-        add("androidTestImplementation", "androidx.test.ext:junit:1.1.2")
-        add("androidTestImplementation", "androidx.test.espresso:espresso-core:3.3.0")
+        add("androidTestImplementation", "androidx.test:core:1.7.0")
+        add("androidTestImplementation", "androidx.test.ext:junit:1.3.0")
+        add("androidTestImplementation", "androidx.test.espresso:espresso-core:3.7.0")
         //androidTestImplementation 'com.android.support.test:runner:1.0.2'
     }
 

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/js/Esbuild.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/js/Esbuild.kt
@@ -31,7 +31,7 @@ fun Project.configureErrorableEsbuild() {
 
     val env by lazy { org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.apply(project.rootProject).requireConfigured() }
     val ENV_PATH by lazy {
-        val NODE_PATH = File(env.nodeExecutable).parent
+        val NODE_PATH = File(env.executable).parent
         val PATH_SEPARATOR = File.pathSeparator
         val OLD_PATH = System.getenv("PATH")
         "$NODE_PATH$PATH_SEPARATOR$OLD_PATH"
@@ -45,7 +45,7 @@ fun Project.configureErrorableEsbuild() {
         doFirst {
             //val nodeDir = env.nodeBinDir
             val nodeDir = env.dir
-            val file1: File = File(env.nodeExecutable)
+            val file1: File = File(env.executable)
             val file2: File? = File(nodeDir, "lib/node_modules/npm/bin/npm-cli.js").takeIf { it.exists() }
             val file3: File? = File(nodeDir, "node_modules/npm/bin/npm-cli.js").takeIf { it.exists() }
             val npmCmd = arrayOf<File>(

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/js/JavaScript.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/js/JavaScript.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.korge.gradle.targets.js
 
 import korlibs.korge.gradle.*
@@ -13,21 +15,13 @@ import org.gradle.api.file.*
 import org.gradle.api.tasks.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 import java.io.*
 
 private object JavaScriptClass
 
 fun Project.configureJavaScript(projectType: ProjectType) {
     if (gkotlin.targets.findByName("js") != null) return
-
-    rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java).allThis {
-        try {
-            rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion =
-                BuildVersions.NODE_JS
-        } catch (e: Throwable) {
-            // Ignore failed because already configured
-        }
-    }
 
     gkotlin.apply {
 		js(KotlinJsCompilerType.IR) {
@@ -38,12 +32,7 @@ fun Project.configureJavaScript(projectType: ProjectType) {
             this.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.js)
 
 			compilations.allThis {
-				kotlinOptions.apply {
-					sourceMap = korge.sourceMaps
-					//metaInfo = true
-					//moduleKind = "umd"
-					suppressWarnings = korge.supressWarnings
-				}
+        // Handled below for all JS compile tasks
 			}
             configureJsTargetOnce()
             configureJSTestsOnce()
@@ -57,8 +46,9 @@ fun Project.configureJavaScript(projectType: ProjectType) {
 	}
 
     // https://youtrack.jetbrains.com/issue/KT-58187/KJS-IR-Huge-performance-bottleneck-while-generating-sourceMaps-getCannonicalFile#focus=Comments-27-7301819.0-0
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile> {
+    tasks.withType(Kotlin2JsCompile::class.java).allThis {
         kotlinOptions.sourceMap = korge.sourceMaps
+        kotlinOptions.suppressWarnings = korge.supressWarnings
     }
 
     val generatedIndexHtmlDir = File(project.buildDir, "processedResources-www")

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/jvm/Jvm.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/jvm/Jvm.kt
@@ -44,10 +44,8 @@ fun Project.configureJvm(projectType: ProjectType) {
             //it.useJUnitPlatform()
         }
     }
-	project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).allThis {
-        kotlinOptions {
-            this.jvmTarget = korge.jvmTarget
-        }
+  project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile::class.java).configureEach {
+    it.compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(korge.jvmTarget))
     }
 
     if (projectType.isExecutable) {

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/native/KotlinNativeCrossTest.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/native/KotlinNativeCrossTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
+
 package korlibs.korge.gradle.targets.native
 
 import korlibs.korge.gradle.targets.*

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/native/NativeExt.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/native/NativeExt.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.*
 import org.jetbrains.kotlin.gradle.tasks.*
 
 fun KotlinNativeCompilation.getLinkTask(kind: NativeOutputKind, type: NativeBuildType, project: Project): KotlinNativeLink {
-	val taskName = "link${type.name.toLowerCase().capitalize()}${kind.name.toLowerCase().capitalize()}${target.name.capitalize()}"
+	val taskName = "link${type.name.lowercase().capitalize()}${kind.name.lowercase().capitalize()}${target.name.capitalize()}"
     val taskName2 = "link${target.name.capitalize()}"
 
 	val tasks = listOf(

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/wasm/ConfigureWasm.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/targets/wasm/ConfigureWasm.kt
@@ -1,3 +1,8 @@
+@file:OptIn(
+    org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class,
+    org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalDistributionDsl::class
+)
+
 package korlibs.korge.gradle.targets.wasm
 
 import korlibs.*
@@ -29,7 +34,11 @@ fun Project.configureWasmTarget(executable: Boolean, binaryen: Boolean = false) 
                 //}
             }
 
-            if (binaryen) applyBinaryen()
+            // Binaryen is enabled by default in recent Kotlin versions.
+            // Keeping the flag for API compatibility, but no explicit call is required.
+            if (binaryen) {
+                // no-op
+            }
         }
 
         sourceSets.maybeCreate("wasmJsTest").apply {

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/util/Dyn.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/util/Dyn.kt
@@ -265,7 +265,7 @@ inline class Dyn(val value: Any?) : Comparable<Dyn> {
         is Number -> toDouble() != 0.0
         is String -> {
             if (extraStrings) {
-                when (value.toLowerCase()) {
+                when (value.lowercase()) {
                     "", "0", "false", "NaN", "null", "undefined", "ko", "no" -> false
                     else -> true
                 }

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/util/Hex.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/util/Hex.kt
@@ -2,8 +2,8 @@ package korlibs.korge.gradle.util
 
 object Hex {
 	private const val DIGITS = "0123456789ABCDEF"
-	val DIGITS_UPPER = DIGITS.toUpperCase()
-	val DIGITS_LOWER = DIGITS.toLowerCase()
+	val DIGITS_UPPER = DIGITS.uppercase()
+    val DIGITS_LOWER = DIGITS.lowercase()
 
 	fun decodeChar(c: Char): Int = when (c) {
 		in '0'..'9' -> c - '0'

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/korge/gradle/util/HttpServerTools.kt
@@ -166,7 +166,7 @@ fun HttpExchange.respond(content: RangedContent, headers: List<Pair<String, Stri
     }
 }
 
-fun File.miniMimeType() = when (this.extension.toLowerCase()) {
+fun File.miniMimeType() = when (this.extension.lowercase()) {
     "htm", "html" -> "text/html"
     "css" -> "text/css"
     "txt" -> "text/plain"

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.gradle.targets.js.npm.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.mocha.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.*
 import java.io.*
 import java.nio.file.*
@@ -121,9 +122,6 @@ object RootKorlibsPlugin {
 
     fun Project.initNodeJSFixes() {
         plugins.applyOnce<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin>()
-        rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java, Action {
-            rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = project.nodeVersion
-        })
         // https://youtrack.jetbrains.com/issue/KT-48273
         afterEvaluate {
             rootProject.extensions.configure(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension::class.java, Action {
@@ -238,7 +236,7 @@ object RootKorlibsPlugin {
                 }
 
                 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
-                    it.kotlinOptions.suppressWarnings = true
+                    it.compilerOptions.suppressWarnings.set(true)
                 }
 
                 afterEvaluate {
@@ -272,12 +270,17 @@ object RootKorlibsPlugin {
 
                     metadata {
                         compilations.allThis {
-                            kotlinOptions.suppressWarnings = true
+                            // Suppress warnings is configured globally for compile tasks above.
                         }
                     }
                     jvm {
                         compilations.allThis {
-                            kotlinOptions.jvmTarget = GRADLE_JAVA_VERSION_STR
+                            compileTaskProvider.configure {
+                                (it as org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile)
+                                    .compilerOptions
+                                    .jvmTarget
+                                    .set(JvmTarget.fromTarget(GRADLE_JAVA_VERSION_STR))
+                            }
                             //kotlinOptions.freeCompilerArgs.add("-Xno-param-assertions")
                             //kotlinOptions.
 

--- a/korge-gradle-plugin/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
+++ b/korge-gradle-plugin/src/main/kotlin/korlibs/root/RootKorlibsPlugin.kt
@@ -21,6 +21,8 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.testing.*
 import org.jetbrains.dokka.gradle.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
 import org.jetbrains.kotlin.gradle.targets.js.npm.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.*
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.*
@@ -29,7 +31,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.*
 import java.io.*
 import java.nio.file.*
-import kotlin.io.path.*
 
 object RootKorlibsPlugin {
     val KORGE_GROUP = "com.soywiz.korge"
@@ -122,10 +123,16 @@ object RootKorlibsPlugin {
 
     fun Project.initNodeJSFixes() {
         plugins.applyOnce<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin>()
+        rootProject.plugins.withType(NodeJsPlugin::class.java, Action {
+            rootProject.extensions.configure(NodeJsEnvSpec::class.java, Action { nodeEnv ->
+                nodeEnv.version.set(project.nodeVersion)
+                nodeEnv.download.set(true)
+            })
+        })
         // https://youtrack.jetbrains.com/issue/KT-48273
         afterEvaluate {
-            rootProject.extensions.configure(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension::class.java, Action {
-                //it.versions.webpackDevServer.version = "4.0.0"
+            rootProject.extensions.configure(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension::class.java, Action { nodeExt ->
+                //nodeExt.versions.webpackDevServer.version = "4.0.0"
             })
         }
     }

--- a/korge-ipc/build.gradle.kts
+++ b/korge-ipc/build.gradle.kts
@@ -21,11 +21,11 @@ java {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions {
-        jvmTarget = jversion
-        apiVersion = "1.8"
-        languageVersion = "1.8"
-        suppressWarnings = true
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jversion))
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("2.1"))
+        suppressWarnings.set(true)
     }
 }
 

--- a/korge-reload-agent/build.gradle.kts
+++ b/korge-reload-agent/build.gradle.kts
@@ -1,5 +1,7 @@
 import korlibs.korge.gradle.targets.android.*
 import korlibs.root.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     //id "kotlin" version "1.6.21"
@@ -30,11 +32,11 @@ java {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions {
-        jvmTarget = jversion
-        apiVersion = "1.6"
-        languageVersion = "1.6"
-        suppressWarnings = true
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(jversion))
+        apiVersion.set(KotlinVersion.fromVersion("2.0"))
+        languageVersion.set(KotlinVersion.fromVersion("2.0"))
+        suppressWarnings.set(true)
     }
 }
 

--- a/korge/build.gradle.kts
+++ b/korge/build.gradle.kts
@@ -13,5 +13,5 @@ project.extensions.extraProperties.properties.apply {
 dependencies {
     commonMainApi(project(":korge-core"))
     jvmMainApi(project(":korge-ipc"))
-    add("jvmMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.9.0-RC")
+    add("jvmMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.10.2")
 }

--- a/korge/src/korlibs/korge/scene/Transition.kt
+++ b/korge/src/korlibs/korge/scene/Transition.kt
@@ -119,7 +119,6 @@ fun Transition.withEasing(easing: Easing) = object : Transition {
 }
 
 /** A [Transition] that will blend [prev] and [next] by adjusting its alphas */
-@SharedImmutable
 val AlphaTransition = Transition("AlphaTransition") { ctx, prev, next, ratio ->
 	val prevAlpha = prev.alphaF
 	val nextAlpha = next.alphaF


### PR DESCRIPTION
- Bumped dependency/tool versions (Kotlin 2.3.20, Korlibs 6.1.0, coroutines,
atomicfu, jna).
- Adapt Gradle/Kotlin DSL usage for newer compiler and plugin APIs.
- Switched Korlibs Maven coordinates from com.soywiz to org.korge and
centralized the Korlibs version via version.ref.
- Migrated compilation configuration from kotlinOptions to compilerOptions and
JvmTarget across build scripts/plugins.
- Updated JS/Node integration to newer Kotlin Gradle plugin APIs.
- Removed/avoided deprecated Kotlin/Native concurrency annotations
(@SharedImmutable) and modernized string case conversions.
- Adjusted Wasm configuration to reflect Binaryen’s default behavior in newer
Kotlin versions.