### PR TITLE
bugfix: Fix e2e test resources android

### DIFF
--- a/e2e/e2e-test/androidApp/build.gradle.kts
+++ b/e2e/e2e-test/androidApp/build.gradle.kts
@@ -28,6 +28,13 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    // TODO Consider moving this to the shared module or the korge plugin configurations
+    sourceSets {
+        getByName("main") {
+            assets.directories.add("../shared/src/commonMain/resources")
+        }
+    }
+
     // Ignore most of the configuration like packaging and signing, as we do not care in e2e tests
     packaging {
         resources {

--- a/e2e/e2e-test/androidApp/src/main/kotlin/org/korge/e2e/MainActivity.kt
+++ b/e2e/e2e-test/androidApp/src/main/kotlin/org/korge/e2e/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : KorgwActivity(config = GameWindowCreationConfig(msaa = 1, f
                 )
 
                 Log.d(TAG, "Determining screenshotsVfs...")
-                val path = Environment["OUTPUT_DIR"] ?: "."
+                val path = applicationContext.getExternalFilesDir(null)!!.absolutePath
                 Log.d(TAG, "Determining screenshotsVfs... $path")
                 val screenshotsVfs = localVfs(path).also { it.mkdirs() }.jail()
                 Log.d(TAG, "vfs: $screenshotsVfs")

--- a/e2e/e2e-test/desktopApp/build.gradle.kts
+++ b/e2e/e2e-test/desktopApp/build.gradle.kts
@@ -12,7 +12,7 @@ korge {
 
     targetJvm()
 
-    jvmMainClassName = "org.korge.e2e.RefMainKt"
+    jvmMainClassName = "org.korge.e2e.jvm.RefMainKt"
 }
 
 kotlin {


### PR DESCRIPTION
## Description

While executing the e2e test example on Android, I noticed that the resources were not loaded properly and the screenshots were not captured.

Additionally, from #2375 we introduced a package missmatch for JVM.

## Solution

This PR addresses all these issues by using an app-specific external storage path, loads explicitly the commonMain resources as assets into the androidApp module, and updates the jvm main class package to match the correct one.

## Additional Information

The fix for loading the common resources as assets into the androidApp module should be only temporary and normally handled by the korge plugin, or at least moved to the shared module's logic. However, this require more time to investigate and figure out how to do it, so I chose the quick solution for now.

You may review the fixes by opening the screenshots on the test device. They can now be found under `/storage/emulated/0/Android/data/org.korge.e2e.test/files/`. Before the fix they were not created (errors were logged), and with both fixes at least the `Filters.png` is different and is rendering the images. I am not sure what the third ping screenshot is supposed to display.